### PR TITLE
disables zenpy object cache to prevent memory exhaustion

### DIFF
--- a/pipelines/zendesk/__init__.py
+++ b/pipelines/zendesk/__init__.py
@@ -220,7 +220,6 @@ def zendesk_support(
         yield [d for d in basic_load(resource_api)]
 
 
-    # TODO: Make caching manageable and editable by users
     # Authenticate
     zendesk_client = auth_zenpy(credentials=credentials)
 

--- a/pipelines/zendesk/helpers/api_helpers.py
+++ b/pipelines/zendesk/helpers/api_helpers.py
@@ -11,8 +11,15 @@ except ImportError:
 from .credentials import ZendeskCredentialsToken, ZendeskCredentialsEmailPass, ZendeskCredentialsOAuth
 
 
-def auth_zenpy(credentials: Union[ZendeskCredentialsOAuth, ZendeskCredentialsToken, ZendeskCredentialsEmailPass], domain: str = "zendesk.com", timeout: Optional[float] = None,
-               ratelimit_budget: Optional[int] = None, proactive_ratelimit: Optional[int] = None, proactive_ratelimit_request_interval: int = 10, disable_cache: bool = False) -> Zenpy:
+def auth_zenpy(
+    credentials: Union[ZendeskCredentialsOAuth, ZendeskCredentialsToken, ZendeskCredentialsEmailPass],
+    domain: str = "zendesk.com",
+    timeout: Optional[float] = None,
+    ratelimit_budget: Optional[int] = None,
+    proactive_ratelimit: Optional[int] = None,
+    proactive_ratelimit_request_interval: int = 10,
+    disable_cache: bool = True
+) -> Zenpy:
     """
     Helper, gets a Zendesk Credentials object and authenticates to the Zendesk API
     @:param: credentials - Zendesk Credentials Object, stores the credentials


### PR DESCRIPTION
# Tell us what you do here

- [ ] contributing new pipeline (please create an issue [here]() and link it below)
- [ ] implementing verified pipeline (please link a relevant issue labelled as `verified pipeline`)
- [ ] fixing a bug (please link a relevant bug report)
- [x] improving, documenting, customizing existing pipeline (please link relevant issue)
- [ ] anything else (please link an issue or describe below)

# Relevant issue

This fixes issues reported on production where Airflow workers were SIGKILLed due to memory pressure
