### PR TITLE
Remove full_refresh args in Hubspot pipeline

### DIFF
--- a/sources/hubspot_pipeline.py
+++ b/sources/hubspot_pipeline.py
@@ -13,11 +13,11 @@ def load_crm_data() -> None:
     """
 
     # Create a DLT pipeline object with the pipeline name, dataset name, and destination database type
+    # Add full_refresh=(True or False) if you need your pipeline to create the dataset in your destination
     p = dlt.pipeline(
         pipeline_name="hubspot_pipeline",
         dataset_name="hubspot",
         destination="redshift",
-        full_refresh=True,
     )
 
     # Run the pipeline with the HubSpot source connector

--- a/tests/hubspot/test_hubspot_source.py
+++ b/tests/hubspot/test_hubspot_source.py
@@ -143,17 +143,3 @@ def test_event_resources(destination_name: str) -> None:
     )
     print(load_info)
     assert_load_info(load_info)
-
-
-@pytest.mark.parametrize("destination_name", ALL_DESTINATIONS)
-def test_event_resources_without_full_refrsh(destination_name: str) -> None:
-    pipeline = dlt.pipeline(
-        pipeline_name="hubspot",
-        destination=destination_name,
-        dataset_name="hubspot_data",
-    )
-    load_info = pipeline.run(
-        hubspot_events_for_objects("company", ["7086461639", "7086464459"])
-    )
-    print(load_info)
-    assert_load_info(load_info)

--- a/tests/hubspot/test_hubspot_source.py
+++ b/tests/hubspot/test_hubspot_source.py
@@ -144,6 +144,7 @@ def test_event_resources(destination_name: str) -> None:
     print(load_info)
     assert_load_info(load_info)
 
+
 @pytest.mark.parametrize("destination_name", ALL_DESTINATIONS)
 def test_event_resources_without_full_refrsh(destination_name: str) -> None:
     pipeline = dlt.pipeline(
@@ -156,4 +157,3 @@ def test_event_resources_without_full_refrsh(destination_name: str) -> None:
     )
     print(load_info)
     assert_load_info(load_info)
-    

--- a/tests/hubspot/test_hubspot_source.py
+++ b/tests/hubspot/test_hubspot_source.py
@@ -143,3 +143,17 @@ def test_event_resources(destination_name: str) -> None:
     )
     print(load_info)
     assert_load_info(load_info)
+
+@pytest.mark.parametrize("destination_name", ALL_DESTINATIONS)
+def test_event_resources_without_full_refrsh(destination_name: str) -> None:
+    pipeline = dlt.pipeline(
+        pipeline_name="hubspot",
+        destination=destination_name,
+        dataset_name="hubspot_data",
+    )
+    load_info = pipeline.run(
+        hubspot_events_for_objects("company", ["7086461639", "7086464459"])
+    )
+    print(load_info)
+    assert_load_info(load_info)
+    


### PR DESCRIPTION
# Tell us what you do here

- [ ] implementing verified source (please link a relevant issue labelled as `verified source`)
- [ ] fixing a bug (please link a relevant bug report)
- [x] improving, documenting, customizing existing source (please link an issue or describe below)
- [ ] anything else (please link an issue or describe below)

# Relevant issue

issue #

# More PR info
- We found out when the  then the pipeline will try ti create the dataset with a suffix as a timestamp, and we want to enable people to use their own datasets or schemas (depends on the destination)
