### PR TITLE
Fix/pipedrive leads

### DIFF
--- a/sources/pipedrive/__init__.py
+++ b/sources/pipedrive/__init__.py
@@ -197,4 +197,3 @@ def leads(
             if first_item and first_item["update_time"] < last_value:
                 return
         yield rename_fields(page, fields_mapping)
-        return

--- a/sources/pipedrive/settings.py
+++ b/sources/pipedrive/settings.py
@@ -9,7 +9,6 @@ ENTITY_MAPPINGS = [
     ("pipeline", None, None),
     ("stage", None, None),
     ("user", None, None),
-    ("lead", None, None),
 ]
 
 RECENTS_ENTITIES = {
@@ -25,5 +24,4 @@ RECENTS_ENTITIES = {
     "product": "products",
     "stage": "stages",
     "user": "users",
-    "lead": "leads",
 }

--- a/tests/pipedrive/test_pipedrive_source.py
+++ b/tests/pipedrive/test_pipedrive_source.py
@@ -35,6 +35,7 @@ ALL_RESOURCES = {
     "products",
     "stages",
     "users",
+    "leads",
 }
 
 TESTED_RESOURCES = (
@@ -46,6 +47,7 @@ TESTED_RESOURCES = (
         "files",
         "activityTypes",
         "notes",
+        "leads",
     }
 )
 
@@ -212,7 +214,7 @@ def test_custom_fields_munger(destination_name: str) -> None:
 def test_since_timestamp() -> None:
     """since_timestamp is coerced correctly to UTC implicit ISO timestamp and passed to endpoint function"""
     with mock.patch(
-        "pipelines.pipedrive.helpers.pages.get_pages",
+        "sources.pipedrive.helpers.pages.get_pages",
         autospec=True,
         return_value=iter([]),
     ) as m:
@@ -227,7 +229,7 @@ def test_since_timestamp() -> None:
     )
 
     with mock.patch(
-        "pipelines.pipedrive.helpers.pages.get_pages",
+        "sources.pipedrive.helpers.pages.get_pages",
         autospec=True,
         return_value=iter([]),
     ) as m:
@@ -239,7 +241,7 @@ def test_since_timestamp() -> None:
     )
 
     with mock.patch(
-        "pipelines.pipedrive.helpers.pages.get_pages",
+        "sources.pipedrive.helpers.pages.get_pages",
         autospec=True,
         return_value=iter([]),
     ) as m:


### PR DESCRIPTION
# Relevant issue

fixes https://github.com/dlt-hub/verified-sources/issues/207

# More PR info

Leads resource from `/leads` endpoint. Incremental loading works by fetching entities in descending order and exit when a lower than last timestamp is reached