### PR TITLE
fixes link to create-a-pipleine docs page

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 This repository contains verified dlt sources and demo pipelines for each source that you can use as a starting point for your project. 
 
 ## How to add a verified source to your dlt project
-`dlt` offers an `init` command that will clone and inject any source with an example pipeline from this repository into your project, setup the credentials and python dependencies. Please follow the step by step instructions in our [docs](https://dlthub.com/docs/walkthroughs/create-a-pipeline).
+`dlt` offers an `init` command that will clone and inject any source with an example pipeline from this repository into your project, setup the credentials and python dependencies. Please follow the step by step instructions in our [docs](https://dlthub.com/docs/walkthroughs/add-a-verified-source).
 ## How to contact us and get help
 Join our slack by following the [invitation link](https://join.slack.com/t/dlthub-community/shared_invite/zt-1n5193dbq-rCBmJ6p~ckpSFK4hCF2dYA)
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 This repository contains verified dlt sources and demo pipelines for each source that you can use as a starting point for your project. 
 
 ## How to add a verified source to your dlt project
-`dlt` offers an `init` command that will clone and inject any source with an example pipeline from this repository into your project, setup the credentials and python dependencies. Please follow the step by step instructions in our [docs](https://dlthub.com/docs/walkthroughs/add-a-pipeline). 
+`dlt` offers an `init` command that will clone and inject any source with an example pipeline from this repository into your project, setup the credentials and python dependencies. Please follow the step by step instructions in our [docs](https://dlthub.com/docs/walkthroughs/create-a-pipeline).
 ## How to contact us and get help
 Join our slack by following the [invitation link](https://join.slack.com/t/dlthub-community/shared_invite/zt-1n5193dbq-rCBmJ6p~ckpSFK4hCF2dYA)
 

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -8,7 +8,7 @@ This may look a little bit weird from software engineering perspective but we wa
 
 ## Use `dlt init` to add a source and its demo pipeline to your project
 
-We'll use the [dlt init](https://dlthub.com/docs/walkthroughs/add-a-pipeline) command to distribute the source.
+We'll use the [dlt init](https://dlthub.com/docs/walkthroughs/create-a-pipeline) command to distribute the source.
 
 
 1. Sources are distributed by `dlt init` command that can be issued several times.

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -8,7 +8,7 @@ This may look a little bit weird from software engineering perspective but we wa
 
 ## Use `dlt init` to add a source and its demo pipeline to your project
 
-We'll use the [dlt init](https://dlthub.com/docs/walkthroughs/create-a-pipeline) command to distribute the source.
+We'll use the [dlt init](https://dlthub.com/docs/walkthroughs/add-a-verified-source) command to distribute the source.
 
 
 1. Sources are distributed by `dlt init` command that can be issued several times.


### PR DESCRIPTION
# Tell us what you do here

- [ ] implementing verified source (please link a relevant issue labelled as `verified source`)
- [ ] fixing a bug (please link a relevant bug report)
- [ ] improving, documenting, customizing existing source (please link an issue or describe below)
- [x] anything else (please link an issue or describe below)

# Relevant issue
This PR corrects links to documentation.

The page https://dlthub.com/docs/walkthroughs/add-a-pipeline does not exist anymore. It's now https://dlthub.com/docs/walkthroughs/create-a-pipeline.


Please correct the link also in the repo description:
![Screenshot 2023-07-14 at 15 09 15](https://github.com/dlt-hub/verified-sources/assets/217980/1140eb95-0757-4053-ac8d-e66418cde46f)
