### PR TITLE
Facebook ads datetime object conversion fix.

### DIFF
--- a/sources/facebook_ads/__init__.py
+++ b/sources/facebook_ads/__init__.py
@@ -186,9 +186,6 @@ def facebook_insights_source(
             query = {
                 "level": level,
                 "action_breakdowns": list(action_breakdowns),
-                "breakdowns": list(
-                    INSIGHTS_BREAKDOWNS_OPTIONS[breakdowns]["breakdowns"]
-                ),
                 "limit": batch_size,
                 "fields": list(
                     set(fields)

--- a/sources/facebook_ads/__init__.py
+++ b/sources/facebook_ads/__init__.py
@@ -10,7 +10,7 @@ from facebook_business.api import FacebookResponse
 import dlt
 from dlt.common import pendulum, logger
 from dlt.common.typing import TDataItems, TDataItem, DictStrAny
-from dlt.common.time import parse_iso_like_datetime
+from dlt.common.time import ensure_pendulum_datetime
 from dlt.extract.typing import ItemTransformFunctionWithMeta
 from dlt.extract.source import DltResource
 

--- a/sources/facebook_ads/helpers.py
+++ b/sources/facebook_ads/helpers.py
@@ -11,7 +11,7 @@ import pendulum
 
 from dlt.common import logger
 from dlt.common.configuration.inject import with_config
-from dlt.common.time import parse_iso_like_datetime
+from dlt.common.time import ensure_pendulum_datetime
 from dlt.common.typing import DictStrAny, TDataItem, TDataItems
 from dlt.extract.typing import ItemTransformFunctionWithMeta
 from dlt.sources.helpers import requests
@@ -38,7 +38,7 @@ def get_start_date(
     """
     Get the start date for incremental loading of Facebook Insights data.
     """
-    start_date: pendulum.DateTime = parse_iso_like_datetime(
+    start_date: pendulum.DateTime = ensure_pendulum_datetime(
         incremental_start_date.start_value
     ).subtract(days=attribution_window_days_lag)
 

--- a/tests/facebook_ads/test_facebook_ads_source.py
+++ b/tests/facebook_ads/test_facebook_ads_source.py
@@ -1,10 +1,12 @@
 import pytest
 
 import dlt
+import pendulum
 
 from sources.facebook_ads import (
     facebook_ads_source,
     facebook_insights_source,
+    get_start_date,
     enrich_ad_objects,
     Campaign,
     DEFAULT_CAMPAIGN_FIELDS,
@@ -88,3 +90,35 @@ def test_load_insights() -> None:
 def test_load_insights_weekly() -> None:
     i_weekly = facebook_insights_source(initial_load_past_days=1, time_increment_days=7)
     assert len(list(i_weekly)) == 0
+
+
+def test_get_start_date() -> pendulum.DateTime:
+    # Test with an ISO datetime string
+    input_value = "2023-08-09T12:30:00"
+    result = get_start_date(
+        incremental_start_date=dlt.sources.incremental("start_date", input_value),
+        attribution_window_days_lag=7,
+    )
+    assert isinstance(result, pendulum.DateTime)
+    assert result.year == 2023
+    assert result.month == 8
+    assert result.day == 2
+    assert result.hour == 12
+    assert result.minute == 30
+    assert result.second == 0
+    assert result.timezone_name == "UTC"
+
+    # Test with an ISO date string
+    input_value = "2023-08-09"
+    result = get_start_date(
+        incremental_start_date=dlt.sources.incremental("start_date", input_value),
+        attribution_window_days_lag=7,
+    )
+    assert isinstance(result, pendulum.DateTime)
+    assert result.year == 2023
+    assert result.month == 8
+    assert result.day == 2
+    assert result.hour == 00
+    assert result.minute == 00
+    assert result.second == 00
+    assert result.timezone_name == "UTC"


### PR DESCRIPTION
# Tell us what you do here

- [ ] implementing verified source (please link a relevant issue labelled as `verified source`)
- [x] fixing a bug (please link a relevant bug report)
- [ ] improving, documenting, customizing existing source (please link an issue or describe below)
- [ ] anything else (please link an issue or describe below)


# More PR info
The helper function **get_start_date()** is using the **parse_iso_like_datetime()** function to convert the ISO datetime string into pendulum.datetime object. The **parse_iso_like_datetime()** function can not handle ISO date string and returns an datetime.date object instead of a pendulum.datetime object.

I replace the **parse_iso_like_datetime()** with **ensure_pendulum_datetime** function inside the  **get_start_date()**. I also wrote some test to ensure that pendulum.datetime is returned.