### PR TITLE
allows running "fork" CI workflow in context of upstream repo

### DIFF
--- a/.github/workflows/test_on_local_destinations_forks.yml
+++ b/.github/workflows/test_on_local_destinations_forks.yml
@@ -2,10 +2,14 @@
 name: test sources on postgres and duckdb on forks
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - master
       - devel
+    types:
+      - opened
+      - synchronize
+      - labeled
   workflow_dispatch:
 
 env:
@@ -14,7 +18,17 @@ env:
   RUNTIME__LOG_LEVEL: ERROR
 
 jobs:
+  authorize:
+    # run when label is assigned OR when we are in loca
+    if: ${{ github.event.label.name == 'ci from fork' || github.event.pull_request.head.repo.full_name == github.repository}}
+    # environment:
+    #   ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+
   get_changed_sources:
+    needs: authorize
     uses: ./.github/workflows/get_changed_sources.yml
     # run only on fork
     # if: ${{ github.event.pull_request.head.repo.fork }}
@@ -54,6 +68,8 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@master
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Setup Python
         uses: actions/setup-python@v1

--- a/.github/workflows/test_on_local_destinations_forks.yml
+++ b/.github/workflows/test_on_local_destinations_forks.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   authorize:
     # run when label is assigned OR when we are in loca
-    if: ${{ github.event.label.name == 'ci from fork' || github.event.pull_request.head.repo.full_name == github.repository}}
+    if: ${{ github.event.label.name == 'ci from fork' || (github.event.pull_request.head.repo.full_name == github.repository && (github.event.action == 'opened' || github.event.action == 'synchronize'))}}
     # environment:
     #   ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/test_on_local_destinations_forks.yml
+++ b/.github/workflows/test_on_local_destinations_forks.yml
@@ -19,10 +19,9 @@ env:
 
 jobs:
   authorize:
-    # run when label is assigned OR when we are in loca
+    # run when label is assigned OR when we are not a fork
+    # see https://iterative.ai/blog/testing-external-contributions-using-github-actions-secrets for inspiration
     if: ${{ github.event.label.name == 'ci from fork' || (github.event.pull_request.head.repo.full_name == github.repository && (github.event.action == 'opened' || github.event.action == 'synchronize'))}}
-    # environment:
-    #   ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
     runs-on: ubuntu-latest
     steps:
       - run: true
@@ -34,7 +33,7 @@ jobs:
     # if: ${{ github.event.pull_request.head.repo.fork }}
 
   run_loader:
-    name: test on local postgres and duckdb on forks
+    name: FORKS - test on local postgres and duckdb
     needs: get_changed_sources
     if: needs.get_changed_sources.outputs.sources_list != ''
     strategy:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -313,8 +313,19 @@ ALL_DESTINATIONS='["postgres"]' pytest tests/chess
 There's also `make test-local` command that will run all the tests on `duckdb` and `postgres`.
 
 ## Github CI: setting credentials and running tests
-If you do pull request from forks, you are not able to see the credentials we set up in the upstream repository. You'll have to do that in your own fork.
+### If you do pull request from your fork to our master branch:
+- linter and init checks will run immediately
+- we will review your code
+- [we will setup secrets/credentials on our side (with your help)](#sharing-and-obtaining-source-credentials-test-accounts-destination-access)
+- we will assign a label **ci from fork** that will enable your verified sources tests against duckdb and postgres
 
+Overall following checks must pass:
+* mypy and linter
+* `dlt init` test where we make sure you provided all information to your verified source module for the distribution to correctly happen
+* tests for your source must pass on **postgres** and **duckdb**
+
+### If you do pull requests within your fork: to your forked master branch
+If you prefer to run your checks on your own CI, do the following:
 1. Go to **settings of your fork** https://github.com/**account name**/**repo name**/settings/secrets/actions
 2. Add new Repository Secrets with a name **DLT_SECRETS_TOML**
 3. Paste the `toml` fragment with source credentials [that you added to your secrets.toml](#3-add-secrets-and-configs-to-run-the-local-tests) - remember to include section name:
@@ -323,13 +334,8 @@ If you do pull request from forks, you are not able to see the credentials we se
 [sources.github]
 access_token="ghp_KZCEQlC8***"
 ```
-
 In essence **DLT_SECRETS_TOML** is just your `secrets.toml` file and will be used as such by the CI runner.
 
-Following checks must pass:
-* mypy and linter
-* `dlt init` test where we make sure you provided all information to your verified source module for the distribution to correctly happen
-* tests for your source must pass on **postgres** and **duckdb**
 
 ### Sharing and obtaining source credentials, test accounts, destination access
 Typically we created a common test account for your source [before you started coding](#walktrough-create-and-contribute-a-new-source). This is an ideal situation - we can reuse your tests directly and can merge your work quickly.


### PR DESCRIPTION
# Tell us what you do here

- [x] anything else (please link an issue or describe below)

# Relevant issue

issue #247 

# More PR info
Changes "fork" workflow to use `pull_request_target` to run PRs in context of the upstream repo:
- if upstream repo and PR repo are same (so this is not a fork) - we always run the workflow
- otherwise we run only when `ci from fork` label is assigned to PR. we assign this label only when code is reviewed and accepted


