### PR TITLE
passed api key to resoures explicitly

### DIFF
--- a/sources/pipedrive/__init__.py
+++ b/sources/pipedrive/__init__.py
@@ -78,7 +78,7 @@ def pipedrive_source(
             name=resource_name,
             primary_key="id",
             write_disposition="merge",
-        )(entity, **resource_kwargs)
+        )(entity, pipedrive_api_key, **resource_kwargs)
 
     yield from endpoints_resources.values()
 

--- a/sources/pipedrive/helpers/pages.py
+++ b/sources/pipedrive/helpers/pages.py
@@ -42,7 +42,7 @@ def get_pages(
 
 def get_recent_items_incremental(
     entity: str,
-    pipedrive_api_key: str = dlt.secrets.value,
+    pipedrive_api_key: str,
     since_timestamp: Optional[dlt.sources.incremental[str]] = dlt.sources.incremental(
         "update_time|modified", "1970-01-01 00:00:00"
     ),

--- a/tests/pipedrive/test_pipedrive_source.py
+++ b/tests/pipedrive/test_pipedrive_source.py
@@ -238,6 +238,8 @@ def test_custom_fields_munger(destination_name: str) -> None:
     table_data = ["TEST FIELD 1"]
     assert_query_data(pipeline, query_string, table_data)
 
+    print(pipeline.state)
+
 
 def test_since_timestamp() -> None:
     """since_timestamp is coerced correctly to UTC implicit ISO timestamp and passed to endpoint function"""


### PR DESCRIPTION
# Tell us what you do here

- [x ] fixing a bug (please link a relevant bug report)

# Relevant issue
`pipedrive_api_key` as received by the source was not passed to resources which resulted in injecting the default