### PR TITLE
fixes yielding partitions in sql_database

### DIFF
--- a/sources/sql_database/helpers.py
+++ b/sources/sql_database/helpers.py
@@ -73,7 +73,7 @@ class TableLoader:
         query = self.make_query()
         with self.engine.connect() as conn:
             result = conn.execution_options(yield_per=self.chunk_size).execute(query)
-            for partition in result.partitions():
+            for partition in result.partitions(size=self.chunk_size):
                 yield [dict(row._mapping) for row in partition]
 
 

--- a/tests/sql_database/sql_source.py
+++ b/tests/sql_database/sql_source.py
@@ -25,10 +25,12 @@ from dlt.common.pendulum import pendulum, timedelta
 
 
 class SQLAlchemySourceDB:
-    def __init__(self, credentials: ConnectionStringCredentials) -> None:
+    def __init__(
+        self, credentials: ConnectionStringCredentials, schema: str = None
+    ) -> None:
         self.credentials = credentials
         self.database_url = credentials.to_native_representation()
-        self.schema = "my_dlt_source" + uniq_id()
+        self.schema = schema or "my_dlt_source" + uniq_id()
         self.engine = create_engine(self.database_url)
         self.metadata = MetaData(schema=self.schema)
         self.table_infos: Dict[str, TableInfo] = {}


### PR DESCRIPTION
# Tell us what you do here
- [ ] fixing a bug (please link a relevant bug report)

# Relevant issue
for some reason, using partition() without `size` yields all results at once, ignoring `yield_per` setting.