### PR TITLE
fixes imports so they use official namespaces

### DIFF
--- a/sources/airtable/__init__.py
+++ b/sources/airtable/__init__.py
@@ -4,7 +4,7 @@ Supports whitelisting of tables or loading of all tables from a specified base.
 from typing import Optional, Iterable, Iterator, List, Dict, Any
 
 import dlt
-from dlt.extract.source import DltResource
+from dlt.sources import DltResource
 from dlt.common.typing import TDataItem
 
 import pyairtable

--- a/sources/asana_dlt/__init__.py
+++ b/sources/asana_dlt/__init__.py
@@ -7,11 +7,10 @@ functions are meant to be used as part of a data loading pipeline.
 """
 
 import typing as t
-from typing import Sequence, Iterable, Dict, Any
+from typing import Iterable, Any
 import dlt
 from dlt.common.typing import TDataItem
 
-from dlt.extract.source import DltResource
 from .settings import (
     PROJECT_FIELDS,
     USER_FIELDS,

--- a/sources/chess/__init__.py
+++ b/sources/chess/__init__.py
@@ -4,8 +4,8 @@ from typing import Callable, Iterator, List, Sequence, Dict, Any
 
 import dlt
 from dlt.common import pendulum
-from dlt.common.typing import TDataItem, StrAny
-from dlt.extract.source import DltResource
+from dlt.common.typing import TDataItem
+from dlt.sources import DltResource
 from dlt.sources.helpers import requests
 from .helpers import get_url_with_retry, get_path_with_retry, validate_month_string
 

--- a/sources/facebook_ads/__init__.py
+++ b/sources/facebook_ads/__init__.py
@@ -12,7 +12,7 @@ from dlt.common import pendulum, logger
 from dlt.common.typing import TDataItems, TDataItem, DictStrAny
 from dlt.common.time import ensure_pendulum_datetime
 from dlt.extract.typing import ItemTransformFunctionWithMeta
-from dlt.extract.source import DltResource
+from dlt.sources import DltResource
 
 from .helpers import (
     get_data_chunked,

--- a/sources/github/__init__.py
+++ b/sources/github/__init__.py
@@ -5,7 +5,7 @@ from typing import Any, Iterator, List, Sequence, Tuple
 import dlt
 from dlt.common.typing import StrAny, DictStrAny, TDataItems
 from dlt.common.utils import chunks
-from dlt.extract.source import DltResource
+from dlt.sources import DltResource
 from dlt.sources.helpers import requests
 
 from .queries import ISSUES_QUERY, RATE_LIMIT, COMMENT_REACTIONS_QUERY

--- a/sources/google_analytics/__init__.py
+++ b/sources/google_analytics/__init__.py
@@ -7,7 +7,7 @@ import dlt
 from dlt.common.exceptions import MissingDependencyException
 from dlt.common.typing import TDataItem, DictStrAny
 
-from dlt.extract.source import DltResource
+from dlt.sources import DltResource
 from dlt.sources.credentials import GcpOAuthCredentials, GcpServiceAccountCredentials
 
 from .helpers.data_processing import to_dict

--- a/sources/google_sheets/__init__.py
+++ b/sources/google_sheets/__init__.py
@@ -5,7 +5,7 @@ from typing import Sequence, Union, Iterable
 import dlt
 from dlt.common import logger
 from dlt.sources.credentials import GcpServiceAccountCredentials, GcpOAuthCredentials
-from dlt.extract.source import DltResource
+from dlt.sources import DltResource
 
 from .helpers.data_processing import (
     ParsedRange,

--- a/sources/hubspot/__init__.py
+++ b/sources/hubspot/__init__.py
@@ -26,12 +26,11 @@ python
 
 from typing import Any, Dict, List, Literal, Sequence, Iterator
 from urllib.parse import quote
-from itertools import chain
 
 import dlt
 from dlt.common import pendulum
 from dlt.common.typing import TDataItems, TDataItem
-from dlt.extract.source import DltResource
+from dlt.sources import DltResource
 
 from .helpers import (
     fetch_data,

--- a/sources/jira/__init__.py
+++ b/sources/jira/__init__.py
@@ -4,7 +4,7 @@ from typing import Iterable, List, Optional
 
 import dlt
 from dlt.common.typing import DictStrAny, TDataItem
-from dlt.extract.source import DltResource
+from dlt.sources import DltResource
 from dlt.sources.helpers import requests
 
 from .settings import DEFAULT_ENDPOINTS, DEFAULT_PAGE_SIZE

--- a/sources/matomo/__init__.py
+++ b/sources/matomo/__init__.py
@@ -3,7 +3,7 @@ from typing import Iterator, List, Iterable
 import dlt
 import pendulum
 from dlt.common.typing import DictStrAny, TDataItem
-from dlt.extract.source import DltResource
+from dlt.sources import DltResource
 from .helpers.matomo_client import MatomoAPIClient
 from .helpers.data_processing import (
     get_matomo_date_range,

--- a/sources/mongodb/__init__.py
+++ b/sources/mongodb/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any, Iterable, List, Optional
 
 import dlt
-from dlt.extract.source import DltResource
+from dlt.sources import DltResource
 
 from .helpers import (
     MongoDbCollectionConfiguration,

--- a/sources/mux/__init__.py
+++ b/sources/mux/__init__.py
@@ -7,7 +7,7 @@ from dlt.common import pendulum
 from dlt.sources.helpers import requests
 from requests.auth import HTTPBasicAuth
 from dlt.common.typing import TDataItem
-from dlt.extract.source import DltResource
+from dlt.sources import DltResource
 
 from .settings import API_BASE_URL, DEFAULT_LIMIT
 

--- a/sources/notion/__init__.py
+++ b/sources/notion/__init__.py
@@ -3,7 +3,7 @@
 from typing import List, Dict, Optional, Iterator
 
 import dlt
-from dlt.extract.source import DltResource
+from dlt.sources import DltResource
 
 from .helpers.client import NotionClient
 from .helpers.database import NotionDatabase

--- a/sources/pipedrive/__init__.py
+++ b/sources/pipedrive/__init__.py
@@ -18,7 +18,7 @@ from .helpers.pages import get_recent_items_incremental, get_pages
 from .helpers import parse_timestamp, group_deal_flows
 from .typing import TDataPage
 from .settings import ENTITY_MAPPINGS, RECENTS_ENTITIES
-from dlt.extract.source import DltResource
+from dlt.sources import DltResource
 from dlt.common import pendulum
 from dlt.extract.typing import DataItemWithMeta
 

--- a/sources/pokemon/__init__.py
+++ b/sources/pokemon/__init__.py
@@ -7,7 +7,7 @@ import typing as t
 from typing import Sequence, Iterable, Dict, Any
 import dlt
 from dlt.common.typing import TDataItem
-from dlt.extract.source import DltResource
+from dlt.sources import DltResource
 from dlt.sources.helpers import requests
 from .settings import BERRY_URL, POKEMON_URL
 

--- a/sources/salesforce/__init__.py
+++ b/sources/salesforce/__init__.py
@@ -8,7 +8,8 @@ To get the security token: https://onlinehelp.coveo.com/en/ces/7.0/administrator
 """
 
 import pendulum
-from dlt.extract.source import DltResource, Incremental
+from dlt.sources import DltResource
+from dlt.extract.source import Incremental
 
 from typing import Iterable
 

--- a/sources/shopify_dlt/__init__.py
+++ b/sources/shopify_dlt/__init__.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Iterator, Iterator, Optional, Iterable
 
 import dlt
 
-from dlt.extract.source import DltResource
+from dlt.sources import DltResource
 from dlt.common.typing import TDataItem, TAnyDateTime
 from dlt.common.time import ensure_pendulum_datetime
 from dlt.common import pendulum

--- a/sources/slack/__init__.py
+++ b/sources/slack/__init__.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Iterable, List, Optional
 
 import dlt
 from dlt.common.typing import TAnyDateTime, TDataItem
-from dlt.extract.source import DltResource
+from dlt.sources import DltResource
 from pendulum import DateTime
 
 from .helpers import SlackAPI, ensure_dt_type

--- a/sources/sql_database/__init__.py
+++ b/sources/sql_database/__init__.py
@@ -5,7 +5,7 @@ from sqlalchemy import MetaData, Table
 from sqlalchemy.engine import Engine
 
 import dlt
-from dlt.extract.source import DltResource
+from dlt.sources import DltResource
 
 
 from dlt.sources.credentials import ConnectionStringCredentials

--- a/sources/sql_database/helpers.py
+++ b/sources/sql_database/helpers.py
@@ -13,7 +13,6 @@ import operator
 
 import dlt
 from dlt.sources.credentials import ConnectionStringCredentials
-from dlt.extract.source import DltResource
 from dlt.common.configuration.specs import BaseConfiguration, configspec
 from dlt.common.typing import TDataItem
 from .settings import DEFAULT_CHUNK_SIZE

--- a/sources/strapi/__init__.py
+++ b/sources/strapi/__init__.py
@@ -2,8 +2,8 @@
 Basic strapi source
 """
 import dlt
-from typing import List, Sequence, Iterable
-from dlt.extract.source import DltResource
+from typing import List, Iterable
+from dlt.sources import DltResource
 
 from .helpers import get_endpoint
 

--- a/sources/strapi/helpers.py
+++ b/sources/strapi/helpers.py
@@ -4,7 +4,6 @@ import math
 from typing import Iterable
 
 from dlt.common.typing import TDataItem
-from dlt.extract.source import DltResource, DltSource
 from dlt.sources.helpers import requests
 
 

--- a/sources/stripe_analytics/__init__.py
+++ b/sources/stripe_analytics/__init__.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Generator, Optional, Tuple, Iterable
 import dlt
 import stripe
 from dlt.common import pendulum
-from dlt.extract.source import DltResource
+from dlt.sources import DltResource
 from dlt.common.typing import TDataItem
 
 from pendulum import DateTime

--- a/sources/unstructured_data/__init__.py
+++ b/sources/unstructured_data/__init__.py
@@ -6,7 +6,7 @@ from typing import Dict
 
 import dlt
 from dlt.common import logger
-from dlt.extract.source import DltResource, TDataItem
+from dlt.sources import DltResource, TDataItem
 
 from .helpers import (
     aprocess_file_to_structured,

--- a/sources/unstructured_data/google_drive/__init__.py
+++ b/sources/unstructured_data/google_drive/__init__.py
@@ -5,7 +5,7 @@ from typing import Any, Sequence, Union
 
 import dlt
 from dlt.common import logger
-from dlt.extract.source import TDataItem, TDataItems
+from dlt.sources import TDataItem, TDataItems
 from dlt.sources.credentials import GcpOAuthCredentials, GcpServiceAccountCredentials
 from googleapiclient.discovery import build  # type: ignore
 

--- a/sources/unstructured_data/inbox/__init__.py
+++ b/sources/unstructured_data/inbox/__init__.py
@@ -6,7 +6,7 @@ from typing import Optional, Sequence
 
 import dlt
 from dlt.common import logger, pendulum
-from dlt.extract.source import DltResource, TDataItem, TDataItems
+from dlt.sources import DltResource, TDataItem, TDataItems
 
 from .helpers import extract_email_info, get_internal_date, get_message_obj
 from .settings import (

--- a/sources/unstructured_data/local_folder/__init__.py
+++ b/sources/unstructured_data/local_folder/__init__.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Sequence, Union
 
 import dlt
-from dlt.extract.source import TDataItem
+from dlt.sources import TDataItem
 
 
 @dlt.resource(write_disposition="replace", name="local_folder")

--- a/sources/workable/__init__.py
+++ b/sources/workable/__init__.py
@@ -4,8 +4,7 @@ import logging
 from typing import Any, Iterable, Optional
 
 import dlt
-from dlt.common.typing import TDataItem, TDataItems
-from dlt.extract.source import DltResource
+from dlt.sources import DltResource, TDataItem, TDataItems
 from pendulum import DateTime
 
 from .workable_client import WorkableClient

--- a/sources/zendesk/__init__.py
+++ b/sources/zendesk/__init__.py
@@ -9,7 +9,7 @@ import dlt
 from dlt.common import pendulum
 from dlt.common.time import ensure_pendulum_datetime
 from dlt.common.typing import TDataItem, TDataItems, TAnyDateTime
-from dlt.extract.source import DltResource
+from dlt.sources import DltResource
 
 from .helpers.api_helpers import process_ticket, process_ticket_field
 from .helpers.talk_api import PaginationType, ZendeskAPIClient

--- a/tests/sql_database/test_sql_database_source.py
+++ b/tests/sql_database/test_sql_database_source.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 import dlt
 from dlt.common.utils import uniq_id
-from dlt.extract.source import DltResource
+from dlt.sources import DltResource
 from dlt.sources.credentials import ConnectionStringCredentials
 
 from sources.sql_database import sql_database, sql_table

--- a/tests/unstructured_data/test_unstructured_data_source.py
+++ b/tests/unstructured_data/test_unstructured_data_source.py
@@ -2,7 +2,8 @@ from typing import Sequence
 
 import dlt
 import pytest
-from dlt.extract.source import DltResource
+
+from dlt.sources import DltResource
 
 from sources.unstructured_data import unstructured_to_structured_resource
 from sources.unstructured_data.google_drive import google_drive_source


### PR DESCRIPTION
# Tell us what you do here
- [x] fixing a bug (please link a relevant bug report)

# More PR info
DltSource and DltResource were imported from "internal" module, not from "official" dlt.sources module. that is fixed here