### PR TITLE
Fix: update_time is NoneType

### DIFF
--- a/sources/pipedrive/__init__.py
+++ b/sources/pipedrive/__init__.py
@@ -173,8 +173,8 @@ def parsed_mapping(
 @dlt.resource(primary_key="id", write_disposition="merge")
 def leads(
     pipedrive_api_key: str = dlt.secrets.value,
-    update_time: Optional[dlt.sources.incremental[str]] = dlt.sources.incremental(
-        "update_time", "1970-01-01 00:00:00"
+    update_time: dlt.sources.incremental[str] = dlt.sources.incremental(
+        "update_time", initial_value=None,
     ),
 ) -> Iterator[TDataPage]:
     """Resource to incrementally load pipedrive leads by update_time"""


### PR DESCRIPTION
fix this issue https://dlthub-community.slack.com/archives/C04DQA7JJN6/p1701947607888769

```
<class 'dlt.extract.exceptions.ResourceExtractionError'>
In processing pipe leads: extraction of resource leads in generator leads caused an exception: 'NoneType' object has no attribute 'last_value'
```
