### PR TITLE
fix(pipedrive): incremental data is None

### DIFF
--- a/sources/inbox/__init__.py
+++ b/sources/inbox/__init__.py
@@ -55,9 +55,9 @@ def inbox_source(
 
     @dlt.resource(name="uids")
     def get_messages_uids(
-        initial_message_num: Optional[
-            dlt.sources.incremental[int]
-        ] = dlt.sources.incremental("message_uid", initial_value=1),
+        initial_message_num: dlt.sources.incremental[int] = dlt.sources.incremental(
+            "message_uid", initial_value=1
+        ),
     ) -> TDataItem:
         """Collects email message UIDs (Unique IDs) from the mailbox.
         Args:

--- a/sources/kinesis/__init__.py
+++ b/sources/kinesis/__init__.py
@@ -19,7 +19,7 @@ from .helpers import get_shard_iterator, max_sequence_by_shard
 def kinesis_stream(
     stream_name: str = dlt.config.value,
     credentials: AwsCredentials = dlt.secrets.value,
-    last_msg: Optional[dlt.sources.incremental[StrStr]] = dlt.sources.incremental(
+    last_msg: dlt.sources.incremental[StrStr] = dlt.sources.incremental(
         "_kinesis", last_value_func=max_sequence_by_shard
     ),
     initial_at_timestamp: TAnyDateTime = 0.0,
@@ -35,7 +35,7 @@ def kinesis_stream(
             value must be present in config/secrets
         credentials (AwsCredentials): The credentials to use to connect to kinesis. If not provided,
             the value from secrets or credentials present on the device will be used.
-        last_msg (Optional[dlt.sources.incremental]): An incremental over a mapping from shard_id to message sequence
+        last_msg (dlt.sources.incremental): An incremental over a mapping from shard_id to message sequence
             that will be used to create shard iterators of type AFTER_SEQUENCE_NUMBER when loading incrementally.
         initial_at_timestamp (TAnyDateTime): An initial timestamp used to generate AT_TIMESTAMP or LATEST iterator when timestamp value is 0
         max_number_of_messages (int): Maximum number of messages to read in one run. Actual read may exceed that number by up to chunk_size. Defaults to None (no limit).

--- a/sources/mongodb/__init__.py
+++ b/sources/mongodb/__init__.py
@@ -18,7 +18,7 @@ def mongodb(
     connection_url: str = dlt.secrets.value,
     database: Optional[str] = dlt.config.value,
     collection_names: Optional[List[str]] = dlt.config.value,
-    incremental: Optional[dlt.sources.incremental] = None,  # type: ignore[type-arg]
+    incremental: dlt.sources.incremental = None,  # type: ignore[type-arg]
     write_disposition: Optional[str] = dlt.config.value,
     parallel: Optional[bool] = dlt.config.value,
 ) -> Iterable[DltResource]:
@@ -30,7 +30,7 @@ def mongodb(
         connection_url (str): Database connection_url.
         database (Optional[str]): Selected database name, it will use the default database if not passed.
         collection_names (Optional[List[str]]): The list of collections `pymongo.collection.Collection` to load.
-        incremental (Optional[dlt.sources.incremental]): Option to enable incremental loading for the collection.
+        incremental (dlt.sources.incremental): Option to enable incremental loading for the collection.
             E.g., `incremental=dlt.sources.incremental('updated_at', pendulum.parse('2022-01-01T00:00:00Z'))`
         write_disposition (str): Write disposition of the resource.
         parallel (Optional[bool]): Option to enable parallel loading for the collection. Default is False.
@@ -68,7 +68,7 @@ def mongodb_collection(
     connection_url: str = dlt.secrets.value,
     database: Optional[str] = dlt.config.value,
     collection: str = dlt.config.value,
-    incremental: Optional[dlt.sources.incremental] = None,  # type: ignore[type-arg]
+    incremental: dlt.sources.incremental = None,  # type: ignore[type-arg]
     write_disposition: Optional[str] = dlt.config.value,
     parallel: Optional[bool] = dlt.config.value,
 ) -> Any:
@@ -79,7 +79,7 @@ def mongodb_collection(
         connection_url (str): Database connection_url.
         database (Optional[str]): Selected database name, it will use the default database if not passed.
         collection (str): The collection name to load.
-        incremental (Optional[dlt.sources.incremental]): Option to enable incremental loading for the collection.
+        incremental (dlt.sources.incremental): Option to enable incremental loading for the collection.
             E.g., `incremental=dlt.sources.incremental('updated_at', pendulum.parse('2022-01-01T00:00:00Z'))`
         write_disposition (str): Write disposition of the resource.
         parallel (Optional[bool]): Option to enable parallel loading for the collection. Default is False.

--- a/sources/mongodb/helpers.py
+++ b/sources/mongodb/helpers.py
@@ -32,7 +32,7 @@ class CollectionLoader:
         self,
         client: TMongoClient,
         collection: TCollection,
-        incremental: Optional[dlt.sources.incremental[Any]] = None,
+        incremental: dlt.sources.incremental[Any] = None,
     ) -> None:
         self.client = client
         self.collection = collection
@@ -110,7 +110,7 @@ class CollectionLoaderParallell(CollectionLoader):
 def collection_documents(
     client: TMongoClient,
     collection: TCollection,
-    incremental: Optional[dlt.sources.incremental[Any]] = None,
+    incremental: dlt.sources.incremental[Any] = None,
     parallel: bool = False,
 ) -> Iterator[TDataItem]:
     """
@@ -120,7 +120,7 @@ def collection_documents(
     Args:
         client (MongoClient): The PyMongo client `pymongo.MongoClient` instance.
         collection (Collection): The collection `pymongo.collection.Collection` to load.
-        incremental: Optional[dlt.sources.incremental[Any]] : The incremental configuration.
+        incremental (dlt.sources.incremental[Any]): The incremental configuration.
         parallel (bool): Option to enable parallel loading for the collection. Default is False.
 
     Returns:

--- a/sources/pipedrive/__init__.py
+++ b/sources/pipedrive/__init__.py
@@ -187,7 +187,6 @@ def leads(
     )
     # Load leads pages sorted from newest to oldest and stop loading when
     # last incremental value is reached
-    last_value = update_time.last_value
     pages = get_pages(
         "leads",
         pipedrive_api_key,

--- a/sources/pipedrive/__init__.py
+++ b/sources/pipedrive/__init__.py
@@ -15,18 +15,19 @@ import dlt
 
 from .helpers.custom_fields_munger import update_fields_mapping, rename_fields
 from .helpers.pages import get_recent_items_incremental, get_pages
-from .helpers import parse_timestamp, group_deal_flows
+from .helpers import group_deal_flows
 from .typing import TDataPage
 from .settings import ENTITY_MAPPINGS, RECENTS_ENTITIES
-from dlt.sources import DltResource
 from dlt.common import pendulum
+from dlt.common.time import ensure_pendulum_datetime
+from dlt.sources import DltResource
 from dlt.extract.typing import DataItemWithMeta
 
 
 @dlt.source(name="pipedrive")
 def pipedrive_source(
     pipedrive_api_key: str = dlt.secrets.value,
-    since_timestamp: Optional[Union[pendulum.DateTime, str]] = dlt.config.value,
+    since_timestamp: Optional[Union[pendulum.DateTime, str]] = "1970-01-01 00:00:00",
 ) -> Iterator[DltResource]:
     """
     Get data from the Pipedrive API. Supports incremental loading and custom fields mapping.
@@ -65,7 +66,9 @@ def pipedrive_source(
     yield create_state(pipedrive_api_key) | parsed_mapping
 
     # parse timestamp and build kwargs
-    since_timestamp = parse_timestamp(since_timestamp)
+    since_timestamp = ensure_pendulum_datetime(since_timestamp).strftime(
+        "%Y-%m-%d %H:%M:%S"
+    )
     resource_kwargs: Any = (
         {"since_timestamp": since_timestamp} if since_timestamp else {}
     )
@@ -173,7 +176,7 @@ def parsed_mapping(
 @dlt.resource(primary_key="id", write_disposition="merge")
 def leads(
     pipedrive_api_key: str = dlt.secrets.value,
-    update_time: Optional[dlt.sources.incremental[str]] = dlt.sources.incremental(
+    update_time: dlt.sources.incremental[str] = dlt.sources.incremental(
         "update_time", "1970-01-01 00:00:00"
     ),
 ) -> Iterator[TDataPage]:
@@ -191,10 +194,7 @@ def leads(
         extra_params={"sort": "update_time DESC"},
     )
     for page in pages:
-        # TODO: This check can be replaced with `update_time.start_out_of_range` in dlt 0.3.5
-        if last_value:
-            # Just check whether first item is lower, worst case we load 1 redundant page before break
-            first_item = page[0] if page else None
-            if first_item and first_item["update_time"] < last_value:
-                return
         yield rename_fields(page, fields_mapping)
+
+        if update_time.start_out_of_range:
+            return

--- a/sources/pipedrive/helpers/__init__.py
+++ b/sources/pipedrive/helpers/__init__.py
@@ -5,18 +5,6 @@ from typing import Any, Iterable, Tuple, Dict, List, cast
 from itertools import groupby
 
 
-def parse_timestamp(timestamp: Any) -> str:
-    if not timestamp:
-        return None
-    if isinstance(timestamp, str):
-        timestamp = pendulum.parse(timestamp)
-    assert isinstance(
-        timestamp, pendulum.DateTime
-    ), "since_timestamp must be a valid ISO datetime string or pendulum.DateTime object"
-    timestamp = timestamp.in_timezone("UTC")
-    return cast(str, timestamp.to_iso8601_string().replace("T", " ").replace("Z", ""))
-
-
 def _deals_flow_group_key(item: Dict[str, Any]) -> str:
     return item["object"]  # type: ignore[no-any-return]
 

--- a/sources/pipedrive/helpers/pages.py
+++ b/sources/pipedrive/helpers/pages.py
@@ -43,7 +43,7 @@ def get_pages(
 def get_recent_items_incremental(
     entity: str,
     pipedrive_api_key: str,
-    since_timestamp: Optional[dlt.sources.incremental[str]] = dlt.sources.incremental(
+    since_timestamp: dlt.sources.incremental[str] = dlt.sources.incremental(
         "update_time|modified", "1970-01-01 00:00:00"
     ),
 ) -> Iterator[TDataPage]:

--- a/sources/sql_database/__init__.py
+++ b/sources/sql_database/__init__.py
@@ -69,7 +69,7 @@ def sql_table(
     table: str = dlt.config.value,
     schema: Optional[str] = dlt.config.value,
     metadata: Optional[MetaData] = None,
-    incremental: Optional[dlt.sources.incremental[Any]] = None,
+    incremental: dlt.sources.incremental[Any] = None,
 ) -> DltResource:
     """
     A dlt resource which loads data from an SQL database table using SQLAlchemy.
@@ -79,7 +79,7 @@ def sql_table(
         table (str): Name of the table to load.
         schema (Optional[str]): Optional name of the schema the table belongs to.
         metadata (Optional[MetaData]): Optional `sqlalchemy.MetaData` instance. If provided, the `schema` argument is ignored.
-        incremental (Optional[dlt.sources.incremental[Any]]): Option to enable incremental loading for the table.
+        incremental (dlt.sources.incremental[Any]): Option to enable incremental loading for the table.
             E.g., `incremental=dlt.sources.incremental('updated_at', pendulum.parse('2022-01-01T00:00:00Z'))`
         write_disposition (str): Write disposition of the resource.
 

--- a/sources/sql_database/helpers.py
+++ b/sources/sql_database/helpers.py
@@ -29,7 +29,7 @@ class TableLoader:
         engine: Engine,
         table: Table,
         chunk_size: int = 1000,
-        incremental: Optional[dlt.sources.incremental[Any]] = None,
+        incremental: dlt.sources.incremental[Any] = None,
     ) -> None:
         self.engine = engine
         self.table = table
@@ -80,7 +80,7 @@ def table_rows(
     engine: Engine,
     table: Table,
     chunk_size: int = DEFAULT_CHUNK_SIZE,
-    incremental: Optional[dlt.sources.incremental[Any]] = None,
+    incremental: dlt.sources.incremental[Any] = None,
 ) -> Iterator[TDataItem]:
     """
     A DLT source which loads data from an SQL database using SQLAlchemy.

--- a/sources/unstructured_data/inbox/__init__.py
+++ b/sources/unstructured_data/inbox/__init__.py
@@ -64,9 +64,9 @@ def messages_uids(
     gmail_group: Optional[str] = GMAIL_GROUP,
     folder: str = "INBOX",
     start_date: pendulum.DateTime = DEFAULT_START_DATE,
-    initial_message_num: Optional[
-        dlt.sources.incremental[int]
-    ] = dlt.sources.incremental("message_uid", initial_value=1),
+    initial_message_num: dlt.sources.incremental[int] = dlt.sources.incremental(
+        "message_uid", initial_value=1
+    ),
 ) -> TDataItem:
     """Collects email message UIDs (Unique IDs) from the mailbox.
 
@@ -78,7 +78,7 @@ def messages_uids(
         gmail_group (str, optional): The email address of the Google Group to filter emails sent to the group. Default is 'GMAIL_GROUP' from settings.
         folder (str, optional): The mailbox folder from which to collect emails. Default is 'INBOX'.
         start_date (pendulum.DateTime, optional): The start date from which to collect emails. Default is 'DEFAULT_START_DATE' from settings.
-        initial_message_num (Optional[dlt.sources.incremental[int]], optional): The initial value for the incremental message UID. Default is 1.
+        initial_message_num (dlt.sources.incremental[int]): The initial value for the incremental message UID. Default is 1.
 
     Yields:
         TDataItem: A dictionary containing the 'message_uid' of the collected email message.

--- a/sources/workable/__init__.py
+++ b/sources/workable/__init__.py
@@ -70,7 +70,7 @@ def workable_source(
 
     @dlt.resource(name="candidates", write_disposition="merge", primary_key="id")
     def candidates_resource(
-        updated_at: Optional[Any] = dlt.sources.incremental(
+        updated_at: Any = dlt.sources.incremental(
             "updated_at", initial_value=workable.start_date_iso
         )
     ) -> Iterable[TDataItem]:


### PR DESCRIPTION
Fixing a bunch of Pipedrive things:

1. let's use `"1970-01-01 00:00:00"` as a default for `since_timestamp`. that should fix the problem
2. let's drop the `Optional` from all Incremental declarations. they are not optional
3. we unified how we deal with datetimes/timestamps in our sources. please look ie. at `def zendesk_talk` and how `TAnyDateTime` is used together with `ensure_pendulum_datetime` (yeah pipedrive is using some non ISO date format... so part of the conversion function should stay)
4. Steini left this comment
```
# TODO: This check can be replaced with `update_time.start_out_of_range` in dlt 0.3.5
```
let's implement it


See the original [issue](https://github.com/dlt-hub/verified-sources/pull/298#issuecomment-1854468600)