### PR TITLE
fix(hubspot): provide default lists of properties

### DIFF
--- a/sources/hubspot/__init__.py
+++ b/sources/hubspot/__init__.py
@@ -96,7 +96,7 @@ def hubspot(
         yield from crm_objects(
             "company",
             api_key,
-            include_history=False,
+            include_history=include_history,
             props=props,
             include_custom_props=include_custom_props,
         )

--- a/sources/hubspot/__init__.py
+++ b/sources/hubspot/__init__.py
@@ -38,7 +38,9 @@ from .helpers import (
     fetch_property_history,
 )
 from .settings import (
+    ALL,
     CRM_OBJECT_ENDPOINTS,
+    CUSTOM_ONLY,
     DEFAULT_COMPANY_PROPS,
     DEFAULT_CONTACT_PROPS,
     DEFAULT_DEAL_PROPS,
@@ -102,7 +104,7 @@ def hubspot(
             "company",
             api_key,
             include_history=False,
-            props=props if props is None else props + global_props,  # type: ignore
+            props=props if props in (ALL, CUSTOM_ONLY) else props + global_props,  # type: ignore
         )
 
     @dlt.resource(name="contacts", write_disposition="replace")
@@ -116,7 +118,7 @@ def hubspot(
             "contact",
             api_key,
             include_history,
-            props if props is None else props + global_props,  # type: ignore
+            props if props in (ALL, CUSTOM_ONLY) else props + global_props,  # type: ignore
         )
 
     @dlt.resource(name="deals", write_disposition="replace")
@@ -130,7 +132,7 @@ def hubspot(
             "deal",
             api_key,
             include_history,
-            props if props is None else props + global_props,  # type: ignore
+            props if props in (ALL, CUSTOM_ONLY) else props + global_props,  # type: ignore
         )
 
     @dlt.resource(name="tickets", write_disposition="replace")
@@ -144,7 +146,7 @@ def hubspot(
             "ticket",
             api_key,
             include_history,
-            props if props is None else props + global_props,  # type: ignore
+            props if props in (ALL, CUSTOM_ONLY) else props + global_props,  # type: ignore
         )
 
     @dlt.resource(name="products", write_disposition="replace")
@@ -158,7 +160,7 @@ def hubspot(
             "product",
             api_key,
             include_history,
-            props if props is None else props + global_props,  # type: ignore
+            props if props in (ALL, CUSTOM_ONLY) else props + global_props,  # type: ignore
         )
 
     @dlt.resource(name="quotes", write_disposition="replace")
@@ -172,7 +174,7 @@ def hubspot(
             "quote",
             api_key,
             include_history,
-            props if props is None else props + global_props,  # type: ignore
+            props if props in (ALL, CUSTOM_ONLY) else props + global_props,  # type: ignore
         )
 
     return companies, contacts, deals, tickets, products, quotes
@@ -185,8 +187,11 @@ def crm_objects(
     props: Sequence[str] = None,
 ) -> Iterator[TDataItems]:
     """Building blocks for CRM resources."""
-    if props is None:
+    if props == ALL:
         props = ",".join(_get_property_names(api_key, object_type))
+    elif props == CUSTOM_ONLY:
+        all_props = _get_property_names(api_key, object_type)
+        props = ",".join([prop for prop in all_props if not prop.startswith("hs_")])
     else:
         props = ",".join(props)
 

--- a/sources/hubspot/__init__.py
+++ b/sources/hubspot/__init__.py
@@ -99,7 +99,10 @@ def hubspot(
     ) -> Iterator[TDataItems]:
         """Hubspot companies resource"""
         yield from crm_objects(
-            "company", api_key, include_history=False, props=props + global_props
+            "company",
+            api_key,
+            include_history=False,
+            props=props if props is None else props + global_props,  # type: ignore
         )
 
     @dlt.resource(name="contacts", write_disposition="replace")
@@ -110,7 +113,10 @@ def hubspot(
     ) -> Iterator[TDataItems]:
         """Hubspot contacts resource"""
         yield from crm_objects(
-            "contact", api_key, include_history, props + global_props
+            "contact",
+            api_key,
+            include_history,
+            props if props is None else props + global_props,  # type: ignore
         )
 
     @dlt.resource(name="deals", write_disposition="replace")
@@ -120,7 +126,12 @@ def hubspot(
         props: Sequence[str] = DEFAULT_DEAL_PROPS,
     ) -> Iterator[TDataItems]:
         """Hubspot deals resource"""
-        yield from crm_objects("deal", api_key, include_history, props + global_props)
+        yield from crm_objects(
+            "deal",
+            api_key,
+            include_history,
+            props if props is None else props + global_props,  # type: ignore
+        )
 
     @dlt.resource(name="tickets", write_disposition="replace")
     def tickets(
@@ -129,7 +140,12 @@ def hubspot(
         props: Sequence[str] = DEFAULT_TICKET_PROPS,
     ) -> Iterator[TDataItems]:
         """Hubspot tickets resource"""
-        yield from crm_objects("ticket", api_key, include_history, props + global_props)
+        yield from crm_objects(
+            "ticket",
+            api_key,
+            include_history,
+            props if props is None else props + global_props,  # type: ignore
+        )
 
     @dlt.resource(name="products", write_disposition="replace")
     def products(
@@ -139,7 +155,10 @@ def hubspot(
     ) -> Iterator[TDataItems]:
         """Hubspot products resource"""
         yield from crm_objects(
-            "product", api_key, include_history, props + global_props
+            "product",
+            api_key,
+            include_history,
+            props if props is None else props + global_props,  # type: ignore
         )
 
     @dlt.resource(name="quotes", write_disposition="replace")
@@ -149,7 +168,12 @@ def hubspot(
         props: Sequence[str] = DEFAULT_QUOTE_PROPS,
     ) -> Iterator[TDataItems]:
         """Hubspot quotes resource"""
-        yield from crm_objects("quote", api_key, include_history, props + global_props)
+        yield from crm_objects(
+            "quote",
+            api_key,
+            include_history,
+            props if props is None else props + global_props,  # type: ignore
+        )
 
     return companies, contacts, deals, tickets, products, quotes
 

--- a/sources/hubspot/helpers.py
+++ b/sources/hubspot/helpers.py
@@ -44,7 +44,10 @@ def extract_property_history(objects: List[Dict[str, Any]]) -> Iterator[Dict[str
 
 
 def fetch_property_history(
-    endpoint: str, api_key: str, props: str, params: Optional[Dict[str, Any]] = None
+    endpoint: str,
+    api_key: str,
+    props: str,
+    params: Optional[Dict[str, Any]] = None,
 ) -> Iterator[List[Dict[str, Any]]]:
     """Fetch property history from the given CRM endpoint.
 

--- a/sources/hubspot/settings.py
+++ b/sources/hubspot/settings.py
@@ -95,3 +95,6 @@ DEFAULT_QUOTE_PROPS = [
     "hs_status",
     "hs_title",
 ]
+
+ALL = "ALL"
+CUSTOM_ONLY = "CUSTOM_ONLY"

--- a/sources/hubspot/settings.py
+++ b/sources/hubspot/settings.py
@@ -96,5 +96,4 @@ DEFAULT_QUOTE_PROPS = [
     "hs_title",
 ]
 
-ALL = "ALL"
-CUSTOM_ONLY = "CUSTOM_ONLY"
+ALL = ("ALL",)

--- a/sources/hubspot/settings.py
+++ b/sources/hubspot/settings.py
@@ -36,3 +36,62 @@ OBJECT_TYPE_SINGULAR = {
 }
 
 OBJECT_TYPE_PLURAL = {v: k for k, v in OBJECT_TYPE_SINGULAR.items()}
+
+DEFAULT_DEAL_PROPS = (
+    "amount",
+    "closedate",
+    "createdate",
+    "dealname",
+    "dealstage",
+    "hs_lastmodifieddate",
+    "hs_object_id",
+    "pipeline",
+)
+
+DEFAULT_COMPANY_PROPS = (
+    "createdate",
+    "domain",
+    "hs_lastmodifieddate",
+    "hs_object_id",
+    "name",
+)
+
+DEFAULT_CONTACT_PROPS = (
+    "createdate",
+    "email",
+    "firstname",
+    "hs_object_id",
+    "lastmodifieddate",
+    "lastname",
+)
+
+DEFAULT_TICKET_PROPS = (
+    "createdate",
+    "content",
+    "hs_lastmodifieddate",
+    "hs_object_id",
+    "hs_pipeline",
+    "hs_pipeline_stage",
+    "hs_ticket_category",
+    "hs_ticket_priority",
+    "subject",
+)
+
+DEFAULT_PRODUCT_PROPS = (
+    "createdate",
+    "description",
+    "hs_lastmodifieddate",
+    "hs_object_id",
+    "name",
+    "price",
+)
+
+DEFAULT_QUOTE_PROPS = (
+    "hs_createdate,"
+    "hs_expiration_date,"
+    "hs_lastmodifieddate,"
+    "hs_object_id,"
+    "hs_public_url_key,"
+    "hs_status,"
+    "hs_title,"
+)

--- a/sources/hubspot/settings.py
+++ b/sources/hubspot/settings.py
@@ -37,7 +37,7 @@ OBJECT_TYPE_SINGULAR = {
 
 OBJECT_TYPE_PLURAL = {v: k for k, v in OBJECT_TYPE_SINGULAR.items()}
 
-DEFAULT_DEAL_PROPS = (
+DEFAULT_DEAL_PROPS = [
     "amount",
     "closedate",
     "createdate",
@@ -46,26 +46,26 @@ DEFAULT_DEAL_PROPS = (
     "hs_lastmodifieddate",
     "hs_object_id",
     "pipeline",
-)
+]
 
-DEFAULT_COMPANY_PROPS = (
+DEFAULT_COMPANY_PROPS = [
     "createdate",
     "domain",
     "hs_lastmodifieddate",
     "hs_object_id",
     "name",
-)
+]
 
-DEFAULT_CONTACT_PROPS = (
+DEFAULT_CONTACT_PROPS = [
     "createdate",
     "email",
     "firstname",
     "hs_object_id",
     "lastmodifieddate",
     "lastname",
-)
+]
 
-DEFAULT_TICKET_PROPS = (
+DEFAULT_TICKET_PROPS = [
     "createdate",
     "content",
     "hs_lastmodifieddate",
@@ -75,23 +75,23 @@ DEFAULT_TICKET_PROPS = (
     "hs_ticket_category",
     "hs_ticket_priority",
     "subject",
-)
+]
 
-DEFAULT_PRODUCT_PROPS = (
+DEFAULT_PRODUCT_PROPS = [
     "createdate",
     "description",
     "hs_lastmodifieddate",
     "hs_object_id",
     "name",
     "price",
-)
+]
 
-DEFAULT_QUOTE_PROPS = (
-    "hs_createdate,"
-    "hs_expiration_date,"
-    "hs_lastmodifieddate,"
-    "hs_object_id,"
-    "hs_public_url_key,"
-    "hs_status,"
-    "hs_title,"
-)
+DEFAULT_QUOTE_PROPS = [
+    "hs_createdate",
+    "hs_expiration_date",
+    "hs_lastmodifieddate",
+    "hs_object_id",
+    "hs_public_url_key",
+    "hs_status",
+    "hs_title",
+]

--- a/sources/hubspot_pipeline.py
+++ b/sources/hubspot_pipeline.py
@@ -69,20 +69,16 @@ def load_crm_objects_with_custom_properties() -> None:
         destination="postgres",
     )
 
-    # set a list of properties, which must be read
-    # from all the included resources
-    source = hubspot(
-        global_props=[
-            "createdate",
-            "hs_analytics_last_timestamp",
-            "hs_analytics_last_visit_timestamp",
-        ]
-    )
+    source = hubspot()
 
-    # set a list of properties, wich must be read
-    # from the `contacts` resource in addition to
-    # the global properties
-    source.contacts.bind(props=["date_of_birth", "degree"])
+    # By default, all the custom properties of a CRM object are extracted,
+    # ignoring those driven by Hubspot (prefixed with `hs_`).
+
+    # To read fields in addition to the custom ones:
+    # source.contacts.bind(props=["date_of_birth", "degree"])
+
+    # To read only two particular fields:
+    source.contacts.bind(props=["date_of_birth", "degree"], include_custom_props=False)
 
     # Run the pipeline with the HubSpot source connector
     info = p.run(source)

--- a/sources/hubspot_pipeline.py
+++ b/sources/hubspot_pipeline.py
@@ -54,6 +54,43 @@ def load_crm_data_with_history() -> None:
     print(info)
 
 
+def load_crm_objects_with_custom_properties() -> None:
+    """
+    Loads CRM objects, reading only properties defined by the user.
+    """
+
+    # Create a DLT pipeline object with the pipeline name,
+    # dataset name, properties to read and destination database
+    # type Add full_refresh=(True or False) if you need your
+    # pipeline to create the dataset in your destination
+    p = dlt.pipeline(
+        pipeline_name="hubspot_pipeline",
+        dataset_name="hubspot",
+        destination="postgres",
+    )
+
+    # set a list of properties, which must be read
+    # from all the included resources
+    source = hubspot(
+        global_props=[
+            "createdate",
+            "hs_analytics_last_timestamp",
+            "hs_analytics_last_visit_timestamp",
+        ]
+    )
+
+    # set a list of properties, wich must be read
+    # from the `contacts` resource in addition to
+    # the global properties
+    source.contacts.bind(props=["date_of_birth", "degree"])
+
+    # Run the pipeline with the HubSpot source connector
+    info = p.run(source)
+
+    # Print information about the pipeline run
+    print(info)
+
+
 def load_web_analytics_events(
     object_type: THubspotObjectType, object_ids: List[str]
 ) -> None:
@@ -86,3 +123,4 @@ if __name__ == "__main__":
     load_crm_data()
     # load_crm_data_with_history()
     # load_web_analytics_events("company", ["7086461639", "7086464459"])
+    # load_crm_objects_with_custom_properties()

--- a/tests/hubspot/test_hubspot_source.py
+++ b/tests/hubspot/test_hubspot_source.py
@@ -229,7 +229,7 @@ def test_all_resources(destination_name: str) -> None:
         full_refresh=True,
     )
     load_info = pipeline.run(hubspot(include_history=True))
-    print(load_info)
+
     assert_load_info(load_info)
     table_names = [
         t["name"]
@@ -252,8 +252,8 @@ def test_all_resources(destination_name: str) -> None:
     # Check history tables
     # NOTE: this value is increasing... maybe we should start testing ranges
     assert load_table_counts(pipeline, *history_table_names) == {
-        "contacts_property_history": 17226,
-        "deals_property_history": 14349,
+        "contacts_property_history": 3616,
+        "deals_property_history": 3662,
     }
 
     # Check property from couple of contacts against known data
@@ -262,7 +262,7 @@ def test_all_resources(destination_name: str) -> None:
             list(row)
             for row in client.execute_sql(
                 """
-                SELECT ch.property_name, ch.value, ch.source_type, ch.source_type, ch.timestamp
+                SELECT ch.property_name, ch.value__v_text, ch.source_type, ch.timestamp
                 FROM contacts
                 JOIN
                 contacts_property_history AS ch ON contacts.id = ch.object_id
@@ -270,6 +270,7 @@ def test_all_resources(destination_name: str) -> None:
                 """
             )
         ]
+
     for row in rows:
         row[-1] = pendulum.instance(row[-1])
 
@@ -279,15 +280,13 @@ def test_all_resources(destination_name: str) -> None:
                 "email",
                 "emailmaria@hubspot.com",
                 "API",
-                "API",
-                pendulum.parse("2022-06-15 08:51:51.399+00"),
+                pendulum.parse("2022-06-15 08:51:51.399"),
             ),
             (
                 "email",
                 "bh@hubspot.com",
                 "API",
-                "API",
-                pendulum.parse("2022-06-15 08:51:51.399+00"),
+                pendulum.parse("2022-06-15 08:51:51.399"),
             ),
         ]
     )

--- a/tests/hubspot/test_hubspot_source.py
+++ b/tests/hubspot/test_hubspot_source.py
@@ -179,12 +179,6 @@ def test_resource_contacts_with_history(destination_name: str, mock_response) ->
 
 @pytest.mark.parametrize("destination_name", ALL_DESTINATIONS)
 def test_too_many_properties(destination_name: str) -> None:
-    pipeline = dlt.pipeline(
-        pipeline_name="hubspot",
-        destination=destination_name,
-        dataset_name="hubspot_data",
-        full_refresh=True,
-    )
     with pytest.raises(ResourceExtractionError):
         source = hubspot(api_key="fake_key", include_history=True)
         source.contacts.bind(props=["property"] * 500)

--- a/tests/hubspot/test_hubspot_source.py
+++ b/tests/hubspot/test_hubspot_source.py
@@ -12,14 +12,13 @@ from dlt.sources.helpers import requests
 from sources.hubspot import hubspot, hubspot_events_for_objects
 from sources.hubspot.helpers import fetch_data, BASE_URL
 from sources.hubspot.settings import (
+    DEFAULT_CONTACT_PROPS,
     CRM_CONTACTS_ENDPOINT,
     CRM_COMPANIES_ENDPOINT,
     CRM_DEALS_ENDPOINT,
     CRM_PRODUCTS_ENDPOINT,
     CRM_TICKETS_ENDPOINT,
     CRM_QUOTES_ENDPOINT,
-    CUSTOM_ONLY,
-    DEFAULT_CONTACT_PROPS,
 )
 from tests.hubspot.mock_data import (
     mock_contacts_data,
@@ -122,9 +121,11 @@ def test_fetch_data_quotes(mock_response):
 @pytest.mark.parametrize("destination_name", ALL_DESTINATIONS)
 def test_resource_contacts_with_history(destination_name: str, mock_response) -> None:
     expected_rows = []
-    global_props = ["global_property1", "global_property2"]
+    expected_props = "address,annualrevenue,associatedcompanyid,associatedcompanylastupdated,city,closedate,company,company_size,country,createdate,currentlyinworkflow,date_of_birth,days_to_close,degree,email,engagements_last_meeting_booked,engagements_last_meeting_booked_campaign,engagements_last_meeting_booked_medium,engagements_last_meeting_booked_source,fax,field_of_study,first_conversion_date,first_conversion_event_name,first_deal_created_date,firstname,followercount,gender,graduation_date,hs_object_id,hubspot_owner_assigneddate,hubspot_owner_id,hubspot_team_id,hubspotscore,industry,ip_city,ip_country,ip_country_code,ip_latlon,ip_state,ip_state_code,ip_zipcode,job_function,jobtitle,kloutscoregeneral,lastmodifieddate,lastname,lifecyclestage,linkedinbio,linkedinconnections,marital_status,message,military_status,mobilephone,notes_last_contacted,notes_last_updated,notes_next_activity_date,num_associated_deals,num_contacted_notes,num_conversion_events,num_notes,num_unique_conversion_events,numemployees,owneremail,ownername,phone,photo,recent_conversion_date,recent_conversion_event_name,recent_deal_amount,recent_deal_close_date,relationship_status,salutation,school,seniority,start_date,state,surveymonkeyeventlastupdated,total_revenue,twitterbio,twitterhandle,twitterprofilephoto,webinareventlastupdated,website,work_email,zip"
 
     def fake_get(url: str, *args, **kwargs) -> Any:  # type: ignore[no-untyped-def]
+        if "/properties" in url:
+            return mock_response(json_data=mock_contacts_properties)
         return mock_response(json_data=mock_contacts_with_history)
 
     for contact in mock_contacts_with_history["results"]:
@@ -141,22 +142,26 @@ def test_resource_contacts_with_history(destination_name: str, mock_response) ->
         source = hubspot(
             api_key="fake_key",
             include_history=True,
-            global_props=global_props,
         )
         load_info = pipeline.run(source.with_resources("contacts"))
 
     assert_load_info(load_info)
 
-    assert m.call_count == 2
+    assert m.call_count == 3
 
     # Check that API is called with all properties listed
     m.assert_has_calls(
         [
             call(
+                urljoin(BASE_URL, "/crm/v3/properties/contacts"),
+                headers=ANY,
+                params=None,
+            ),
+            call(
                 urljoin(BASE_URL, CRM_CONTACTS_ENDPOINT),
                 headers=ANY,
                 params={
-                    "properties": ",".join(DEFAULT_CONTACT_PROPS + global_props),
+                    "properties": expected_props,
                     "limit": 100,
                 },
             ),
@@ -164,9 +169,7 @@ def test_resource_contacts_with_history(destination_name: str, mock_response) ->
                 urljoin(BASE_URL, CRM_CONTACTS_ENDPOINT),
                 headers=ANY,
                 params={
-                    "propertiesWithHistory": ",".join(
-                        DEFAULT_CONTACT_PROPS + global_props
-                    ),
+                    "propertiesWithHistory": expected_props,
                     "limit": 50,
                 },
             ),
@@ -187,10 +190,88 @@ def test_too_many_properties(destination_name: str) -> None:
 
 
 @pytest.mark.parametrize("destination_name", ALL_DESTINATIONS)
-def test_custom_properties(destination_name: str, mock_response) -> None:
+def test_only_users_properties(destination_name: str, mock_response) -> None:
     def fake_get(url: str, *args, **kwargs) -> Any:  # type: ignore[no-untyped-def]
+        if "/properties" in url:
+            return mock_response(json_data=mock_contacts_properties)
         return mock_response(json_data=mock_contacts_with_history)
 
+    expected_props = "prop1,prop2,prop3"
+    props = ["prop1", "prop2", "prop3"]
+
+    pipeline = dlt.pipeline(
+        pipeline_name="hubspot",
+        destination=destination_name,
+        dataset_name="hubspot_data",
+        full_refresh=True,
+    )
+    source = hubspot(api_key="fake_key")
+    source.contacts.bind(props=props, include_custom_props=False)
+
+    with patch("dlt.sources.helpers.requests.get", side_effect=fake_get) as m:
+        load_info = pipeline.run(source.with_resources("contacts"))
+
+    assert_load_info(load_info)
+
+    m.assert_has_calls(
+        [
+            call(
+                urljoin(BASE_URL, CRM_CONTACTS_ENDPOINT),
+                headers=ANY,
+                params={
+                    "properties": expected_props,
+                    "limit": 100,
+                },
+            ),
+        ]
+    )
+
+
+@pytest.mark.parametrize("destination_name", ALL_DESTINATIONS)
+def test_only_default_props(destination_name: str, mock_response) -> None:
+    def fake_get(url: str, *args, **kwargs) -> Any:  # type: ignore[no-untyped-def]
+        if "/properties" in url:
+            return mock_response(json_data=mock_contacts_properties)
+        return mock_response(json_data=mock_contacts_with_history)
+
+    expected_props = ",".join(DEFAULT_CONTACT_PROPS)
+
+    pipeline = dlt.pipeline(
+        pipeline_name="hubspot",
+        destination=destination_name,
+        dataset_name="hubspot_data",
+        full_refresh=True,
+    )
+    source = hubspot(api_key="fake_key")
+    source.contacts.bind(include_custom_props=False)
+
+    with patch("dlt.sources.helpers.requests.get", side_effect=fake_get) as m:
+        load_info = pipeline.run(source.with_resources("contacts"))
+
+    assert_load_info(load_info)
+
+    m.assert_has_calls(
+        [
+            call(
+                urljoin(BASE_URL, CRM_CONTACTS_ENDPOINT),
+                headers=ANY,
+                params={
+                    "properties": expected_props,
+                    "limit": 100,
+                },
+            ),
+        ]
+    )
+
+
+@pytest.mark.parametrize("destination_name", ALL_DESTINATIONS)
+def test_users_and_custom_properties(destination_name: str, mock_response) -> None:
+    def fake_get(url: str, *args, **kwargs) -> Any:  # type: ignore[no-untyped-def]
+        if "/properties" in url:
+            return mock_response(json_data=mock_contacts_properties)
+        return mock_response(json_data=mock_contacts_with_history)
+
+    expected_props = "address,annualrevenue,associatedcompanyid,associatedcompanylastupdated,city,closedate,company,company_size,country,createdate,currentlyinworkflow,date_of_birth,days_to_close,degree,email,engagements_last_meeting_booked,engagements_last_meeting_booked_campaign,engagements_last_meeting_booked_medium,engagements_last_meeting_booked_source,fax,field_of_study,first_conversion_date,first_conversion_event_name,first_deal_created_date,firstname,followercount,gender,graduation_date,hubspot_owner_assigneddate,hubspot_owner_id,hubspot_team_id,hubspotscore,industry,ip_city,ip_country,ip_country_code,ip_latlon,ip_state,ip_state_code,ip_zipcode,job_function,jobtitle,kloutscoregeneral,lastmodifieddate,lastname,lifecyclestage,linkedinbio,linkedinconnections,marital_status,message,military_status,mobilephone,notes_last_contacted,notes_last_updated,notes_next_activity_date,num_associated_deals,num_contacted_notes,num_conversion_events,num_notes,num_unique_conversion_events,numemployees,owneremail,ownername,phone,photo,prop1,prop2,prop3,recent_conversion_date,recent_conversion_event_name,recent_deal_amount,recent_deal_close_date,relationship_status,salutation,school,seniority,start_date,state,surveymonkeyeventlastupdated,total_revenue,twitterbio,twitterhandle,twitterprofilephoto,webinareventlastupdated,website,work_email,zip"
     props = ["prop1", "prop2", "prop3"]
 
     pipeline = dlt.pipeline(
@@ -210,10 +291,15 @@ def test_custom_properties(destination_name: str, mock_response) -> None:
     m.assert_has_calls(
         [
             call(
+                urljoin(BASE_URL, "/crm/v3/properties/contacts"),
+                headers=ANY,
+                params=None,
+            ),
+            call(
                 urljoin(BASE_URL, CRM_CONTACTS_ENDPOINT),
                 headers=ANY,
                 params={
-                    "properties": ",".join(props),
+                    "properties": expected_props,
                     "limit": 100,
                 },
             ),
@@ -235,7 +321,6 @@ def test_custom_only_properties(destination_name: str, mock_response) -> None:
         full_refresh=True,
     )
     source = hubspot(api_key="fake_key")
-    source.contacts.bind(props=CUSTOM_ONLY)
 
     with patch("dlt.sources.helpers.requests.get", side_effect=fake_get) as m:
         load_info = pipeline.run(source.with_resources("contacts"))
@@ -243,7 +328,7 @@ def test_custom_only_properties(destination_name: str, mock_response) -> None:
     assert_load_info(load_info)
 
     for prop in m.mock_calls[1][2]["params"]["properties"].split(","):
-        assert not prop.startswith("hs_")
+        assert not prop.startswith("hs_") or prop == "hs_object_id"
 
 
 @pytest.mark.parametrize("destination_name", ALL_DESTINATIONS)
@@ -278,8 +363,8 @@ def test_all_resources(destination_name: str) -> None:
     # Check history tables
     # NOTE: this value is increasing... maybe we should start testing ranges
     assert load_table_counts(pipeline, *history_table_names) == {
-        "contacts_property_history": 3616,
-        "deals_property_history": 3662,
+        "contacts_property_history": 5935,
+        "deals_property_history": 5162,
     }
 
     # Check property from couple of contacts against known data
@@ -288,7 +373,7 @@ def test_all_resources(destination_name: str) -> None:
             list(row)
             for row in client.execute_sql(
                 """
-                SELECT ch.property_name, ch.value__v_text, ch.source_type, ch.timestamp
+                SELECT ch.property_name, ch.value, ch.source_type, ch.timestamp
                 FROM contacts
                 JOIN
                 contacts_property_history AS ch ON contacts.id = ch.object_id

--- a/tests/hubspot/test_hubspot_source.py
+++ b/tests/hubspot/test_hubspot_source.py
@@ -363,6 +363,7 @@ def test_all_resources(destination_name: str) -> None:
     # Check history tables
     # NOTE: this value is increasing... maybe we should start testing ranges
     assert load_table_counts(pipeline, *history_table_names) == {
+        "companies_property_history": 4018,
         "contacts_property_history": 5935,
         "deals_property_history": 5162,
     }


### PR DESCRIPTION
Fixes #305 

The error `414 URI too long` happens, because we request the list of all the possible properties for an object here:
https://github.com/dlt-hub/verified-sources/blob/a1cf60a718389f63b1b73b3a6e1c92432ee7c269/sources/hubspot/helpers.py#L165-L184

In some cases, object has so many properties, that their list joined by `,` becomes longer than 8000 of symbols, which causes `414`.

**Proposed solution**:
Instead of reading all the possible properties (most of which are very low-level and unlikely needed, like number of the broker, which processed the record), we create a default list of properties for every endpoint. The default lists are copied from the Hubspot `search` (see https://developers.hubspot.com/docs/api/crm/search#crm-objects), so for Hubspot users it should be an expected behavior.

However, if user wants, they can initiate a resource with their own list of properties to read, e.g.:
```python
load_info = pipeline.run(
            contacts(api_key="fake_key", include_history=True, props=["prop1", "prop2"])
        )
```

In case the user still wants to try to read all the possible properties, they can send `props=None` - in this case, we'll work the old way. The length of the properties list depends on many factors, so it can still work fine in many cases.