### PR TITLE
sql-database: detect precision and scale of supported column types

### DIFF
--- a/sources/sql_database/schema_types.py
+++ b/sources/sql_database/schema_types.py
@@ -1,0 +1,61 @@
+from typing import Any, Optional
+
+from sqlalchemy.sql import sqltypes
+from sqlalchemy import Table, Column
+
+from dlt.common.schema.typing import TColumnSchema, TTableSchemaColumns
+
+
+def sqla_col_to_column_schema(sql_col: Column[Any]) -> Optional[TColumnSchema]:
+    """Infer dlt schema column type from an sqlalchemy type.
+
+    Precision and scale is inferred from that types that support it,
+    such as numeric, varchar, int, bigint
+    """
+    sql_t = sql_col.type
+    col = None
+
+    if isinstance(sql_t, sqltypes.BigInteger):
+        col = dict(name=sql_col.name, data_type="bigint", precision=64)
+    elif isinstance(sql_t, sqltypes.SmallInteger):
+        col = dict(name=sql_col.name, data_type="bigint", precision=16)
+    elif isinstance(sql_t, sqltypes.Integer):
+        col = dict(name=sql_col.name, data_type="bigint", precision=32)
+    elif isinstance(sql_t, sqltypes.Numeric) and not isinstance(sql_t, sqltypes.Float):
+        col = dict(
+            name=sql_col.name,
+            data_type="decimal",
+            precision=sql_t.precision,
+            scale=sql_t.scale,
+        )
+    elif isinstance(sql_t, sqltypes.String):
+        col = dict(name=sql_col.name, data_type="text", precision=sql_t.length)
+    elif isinstance(sql_t, sqltypes._Binary):
+        col = dict(name=sql_col.name, data_type="binary", precision=sql_t.length)
+    elif isinstance(sql_t, sqltypes.DateTime):
+        col = dict(
+            name=sql_col.name,
+            data_type="timestamp",
+            precision=getattr(sql_t, "precision", None),
+        )
+    elif isinstance(sql_t, sqltypes.Time):
+        col = dict(
+            name=sql_col.name,
+            data_type="time",
+            precision=getattr(sql_t, "precision", None),
+        )
+    if col:
+        return {key: value for key, value in col.items() if value is not None}  # type: ignore[return-value]
+    return None
+
+
+def table_to_columns(table: Table) -> TTableSchemaColumns:
+    """Convert an sqlalchemy table to a dlt table schema.
+
+    Only columns types supporting precision/scale are included in result.
+    """
+    return {
+        col["name"]: col
+        for col in (sqla_col_to_column_schema(c) for c in table.columns)
+        if col is not None
+    }


### PR DESCRIPTION
# Tell us what you do here

- [x] improving, documenting, customizing existing source (please link an issue or describe below)

Detects precision and scale attributes for reflected columns in the source database.

Types supported:

`int/bigint/smallint` -> `bigint` with corresponding precision
`numeric` -> `decimal` with precision (sqlalchemy `Numeric` is base of all "decimal" like types)
`timestamp/time` -> dlt `timestamp/time` with precision
`string/binary` -> `text`/`binary` with length as precision

Detects types using the base type classes in `sqlalchemy.sql.sqltypes` so should work for all dialects.

# Relevant issue

resolves  https://github.com/dlt-hub/verified-sources/issues/323