### PR TITLE
Squash messages to one table for slack

### DIFF
--- a/sources/slack/__init__.py
+++ b/sources/slack/__init__.py
@@ -215,7 +215,7 @@ def slack_source(
 
     def table_name_func(channel_name: str, payload: TDataItem) -> str:
         """Return the table name for a given channel and payload."""
-        table_type = payload.get("subtype", payload["type"])
+        table_type = payload.get("subtype", payload.get("type", ""))
         return f"{channel_name}_{table_type}"
 
     # It will not work in the pipeline or tests because it is a paid feature,

--- a/sources/slack/helpers.py
+++ b/sources/slack/helpers.py
@@ -7,7 +7,7 @@ from urllib.parse import urljoin
 import pendulum
 from dlt.common.time import ensure_pendulum_datetime
 from dlt.common.typing import Dict, TAnyDateTime, TDataItem
-from dlt.sources.helpers.requests.retry import Client
+from dlt.sources.helpers import requests
 from jsonpath_ng.ext import parse  # type: ignore
 
 from .settings import MAX_PAGE_SIZE, SLACK_API_URL
@@ -75,7 +75,6 @@ class SlackAPI:
         """
         self.access_token = access_token
         self.page_size = page_size
-        self.request = Client(respect_retry_after_header=True)
 
     @property
     def headers(self) -> Dict[str, str]:
@@ -174,7 +173,7 @@ class SlackAPI:
         # Iterate through all pages
         while has_next_page:
             # Make the request
-            response = self.request.get(
+            response = requests.get(
                 url=self.url(resource),
                 headers=self.headers,
                 params=self.parameters(params or {}, next_cursor),

--- a/sources/slack/helpers.py
+++ b/sources/slack/helpers.py
@@ -7,7 +7,7 @@ from urllib.parse import urljoin
 import pendulum
 from dlt.common.time import ensure_pendulum_datetime
 from dlt.common.typing import Dict, TAnyDateTime, TDataItem
-from dlt.sources.helpers import requests
+from dlt.sources.helpers.requests.retry import Client
 from jsonpath_ng.ext import parse  # type: ignore
 
 from .settings import MAX_PAGE_SIZE, SLACK_API_URL
@@ -75,6 +75,7 @@ class SlackAPI:
         """
         self.access_token = access_token
         self.page_size = page_size
+        self.request = Client(respect_retry_after_header=True)
 
     @property
     def headers(self) -> Dict[str, str]:
@@ -173,7 +174,7 @@ class SlackAPI:
         # Iterate through all pages
         while has_next_page:
             # Make the request
-            response = requests.get(
+            response = self.request.get(
                 url=self.url(resource),
                 headers=self.headers,
                 params=self.parameters(params or {}, next_cursor),

--- a/sources/slack_pipeline.py
+++ b/sources/slack_pipeline.py
@@ -7,7 +7,7 @@ from pendulum import datetime
 from slack import slack_source
 
 
-def load_all_resources() -> None:
+def load_all_resources(replies: bool = False) -> None:
     """Load all resources from slack without any selection of channels."""
 
     pipeline = dlt.pipeline(
@@ -15,10 +15,13 @@ def load_all_resources() -> None:
     )
 
     source = slack_source(
-        page_size=1000, start_date=datetime(2023, 9, 1), end_date=datetime(2023, 9, 8)
+        page_size=1000,
+        start_date=datetime(2023, 9, 1),
+        end_date=datetime(2023, 9, 8),
+        replies=replies,
     )
 
-    # Uncomment the following line to load only the access_logs resource. It is not selectes
+    # Uncomment the following line to load only the access_logs resource. It is not selected
     # by default because it is a resource just available on paid accounts.
     # source.access_logs.selected = True
 
@@ -71,8 +74,11 @@ if __name__ == "__main__":
     # resources = ["access_logs", "conversations", "conversations_history"]
 
     # load_all_resources()
-    # select_resource(selected_channels=["dlt-github-ci"])
 
+    # load all resources with replies
+    # load_all_resources(replies=True)
+
+    # select_resource(selected_channels=["dlt-github-ci"])
     # select_resource(selected_channels=["1-announcements", "dlt-github-ci"])
 
     get_users()

--- a/tests/slack/test_slack_source.py
+++ b/tests/slack/test_slack_source.py
@@ -28,18 +28,38 @@ def test_all_resources(destination_name: str) -> None:
     table_names = [t["name"] for t in pipeline.default_schema.data_tables()]
     table_counts = load_table_counts(pipeline, *table_names)
 
-    ci_table = "dlt-github-ci_message"
-    announcements_table = "_1-announcements_message"
-    # just duckdb supports "-" in table names
-    if destination_name != "duckdb":
-        ci_table = ci_table.replace("-", "_")
-        announcements_table = announcements_table.replace("-", "_")
-    expected_tables = ["channels", ci_table, announcements_table]
+    expected_tables = ["channels", "messages"]
 
     assert set(table_counts.keys()) >= set(expected_tables)
+    assert "replies" not in table_names
     assert table_counts["channels"] >= 15
-    assert table_counts[ci_table] == 24
-    assert table_counts[announcements_table] == 2
+    assert table_counts["messages"] == 26
+
+
+@pytest.mark.parametrize("destination_name", ALL_DESTINATIONS)
+def test_replies(destination_name: str) -> None:
+    pipeline = dlt.pipeline(
+        pipeline_name="slack",
+        destination=destination_name,
+        dataset_name="slack_data",
+        full_refresh=True,
+    )
+
+    # Set page size to ensure we use pagination
+    source = slack_source(
+        page_size=20,
+        start_date=datetime(2023, 9, 1),
+        end_date=datetime(2023, 9, 8),
+        selected_channels=["dlt-github-ci", "1-announcements"],
+        replies=True,
+    )
+    load_info = pipeline.run(source)
+    assert_load_info(load_info)
+
+    table_names = [t["name"] for t in pipeline.default_schema.data_tables()]
+    table_counts = load_table_counts(pipeline, *table_names)
+    assert "replies" in table_names
+    assert table_counts["replies"] >= 10
 
 
 @pytest.mark.parametrize("destination_name", ALL_DESTINATIONS)

--- a/tests/slack/test_slack_source.py
+++ b/tests/slack/test_slack_source.py
@@ -18,8 +18,8 @@ def test_all_resources(destination_name: str) -> None:
     # Set page size to ensure we use pagination
     source = slack_source(
         page_size=20,
-        start_date=datetime(2023, 9, 1),
-        end_date=datetime(2023, 9, 8),
+        start_date=datetime(2024, 1, 31),
+        end_date=datetime(2024, 2, 1),
         selected_channels=["dlt-github-ci", "1-announcements"],
     )
     load_info = pipeline.run(source)
@@ -33,7 +33,7 @@ def test_all_resources(destination_name: str) -> None:
     assert set(table_counts.keys()) >= set(expected_tables)
     assert "replies" not in table_names
     assert table_counts["channels"] >= 15
-    assert table_counts["messages"] == 26
+    assert table_counts["messages"] == 34
 
 
 @pytest.mark.parametrize("destination_name", ALL_DESTINATIONS)
@@ -48,9 +48,9 @@ def test_replies(destination_name: str) -> None:
     # Set page size to ensure we use pagination
     source = slack_source(
         page_size=20,
-        start_date=datetime(2023, 9, 1),
-        end_date=datetime(2023, 9, 8),
-        selected_channels=["dlt-github-ci", "1-announcements"],
+        start_date=datetime(2023, 12, 19),
+        end_date=datetime(2024, 1, 10),
+        selected_channels=["1-announcements"],
         replies=True,
     )
     load_info = pipeline.run(source)
@@ -59,7 +59,7 @@ def test_replies(destination_name: str) -> None:
     table_names = [t["name"] for t in pipeline.default_schema.data_tables()]
     table_counts = load_table_counts(pipeline, *table_names)
     assert "replies" in table_names
-    assert table_counts["replies"] >= 10
+    assert table_counts["replies"] >= 5
 
 
 @pytest.mark.parametrize("destination_name", ALL_DESTINATIONS)

--- a/tests/slack/test_slack_source.py
+++ b/tests/slack/test_slack_source.py
@@ -17,7 +17,6 @@ def test_tabel_per_channel(destination_name: str) -> None:
 
     # Set page size to ensure we use pagination
     source = slack_source(
-        page_size=20,
         start_date=datetime(2024, 1, 31),
         end_date=datetime(2024, 2, 1),
         selected_channels=["dlt-github-ci", "3-technical-help"],
@@ -49,7 +48,7 @@ def test_all_resources(destination_name: str) -> None:
 
     # Set page size to ensure we use pagination
     source = slack_source(
-        page_size=20,
+        page_size=40,
         start_date=datetime(2024, 1, 31),
         end_date=datetime(2024, 2, 1),
         selected_channels=["dlt-github-ci", "1-announcements"],
@@ -80,7 +79,6 @@ def test_replies(destination_name: str) -> None:
 
     # Set page size to ensure we use pagination
     source = slack_source(
-        page_size=20,
         start_date=datetime(2023, 12, 19),
         end_date=datetime(2024, 1, 10),
         selected_channels=["1-announcements"],


### PR DESCRIPTION
# Tell us what you do here

- [ ] implementing verified source (please link a relevant issue labeled as `verified source`)
- [ ] fixing a bug (please link a relevant bug report)
- [x] improving, documenting, or customizing an existing source (please link an issue or describe below)
    * Now all messages are extracted into one table instead of a table per channel. 
    * Add replies resource. Now replies are also extracted by slack source
- [ ] anything else (please link an issue or describe below)