### PR TITLE
allows for delayed table reflection, column selection and buffer control in sql_database

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -502,7 +502,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "dlt"
-version = "0.4.3a0"
+version = "0.4.4"
 description = "dlt is an open-source python-first scalable data loading library that does not require any backend to run."
 category = "main"
 optional = false
@@ -523,13 +523,13 @@ hexbytes = ">=0.2.2"
 humanize = ">=4.4.0"
 jsonpath-ng = ">=1.5.3"
 makefun = ">=1.15.0"
-orjson = {version = ">=3.6.7", markers = "platform_python_implementation != \"PyPy\""}
+orjson = {version = ">=3.6.7,<=3.9.10", markers = "platform_python_implementation != \"PyPy\""}
 packaging = ">=21.1"
 pathvalidate = ">=2.5.2"
 pendulum = ">=2.1.2"
 psycopg2-binary = {version = ">=2.9.1", optional = true, markers = "extra == \"postgres\" or extra == \"redshift\""}
 psycopg2cffi = {version = ">=2.9.0", optional = true, markers = "platform_python_implementation == \"PyPy\" and (extra == \"postgres\" or extra == \"redshift\")"}
-pyarrow = {version = ">=12.0.0", optional = true, markers = "extra == \"bigquery\" or extra == \"parquet\" or extra == \"motherduck\" or extra == \"athena\""}
+pyarrow = {version = ">=12.0.0", optional = true, markers = "extra == \"bigquery\" or extra == \"parquet\" or extra == \"motherduck\" or extra == \"athena\" or extra == \"synapse\""}
 pytz = ">=2022.6"
 PyYAML = ">=5.4.1"
 requests = ">=2.26.0"
@@ -550,7 +550,8 @@ athena = ["botocore (>=1.28)", "pyarrow (>=12.0.0)", "pyathena (>=2.9.6)", "s3fs
 az = ["adlfs (>=2022.4.0)"]
 bigquery = ["gcsfs (>=2022.4.0)", "google-cloud-bigquery (>=2.26.0)", "grpcio (>=1.50.0)", "pyarrow (>=12.0.0)"]
 cli = ["cron-descriptor (>=1.2.32)", "pipdeptree (>=2.9.0,<2.10)"]
-dbt = ["dbt-athena-community (>=1.2.0)", "dbt-bigquery (>=1.2.0)", "dbt-core (>=1.2.0)", "dbt-duckdb (>=1.2.0)", "dbt-redshift (>=1.2.0)", "dbt-snowflake (>=1.2.0)"]
+databricks = ["databricks-sql-connector (>=2.9.3,<3.0.0)"]
+dbt = ["dbt-athena-community (>=1.2.0)", "dbt-bigquery (>=1.2.0)", "dbt-core (>=1.2.0)", "dbt-databricks (>=1.7.3,<2.0.0)", "dbt-duckdb (>=1.2.0)", "dbt-redshift (>=1.2.0)", "dbt-snowflake (>=1.2.0)"]
 duckdb = ["duckdb (>=0.6.1,<0.10.0)"]
 filesystem = ["botocore (>=1.28)", "s3fs (>=2022.4.0)"]
 gcp = ["gcsfs (>=2022.4.0)", "google-cloud-bigquery (>=2.26.0)", "grpcio (>=1.50.0)"]
@@ -563,6 +564,7 @@ qdrant = ["qdrant-client[fastembed] (>=1.6.4,<2.0.0)"]
 redshift = ["psycopg2-binary (>=2.9.1)", "psycopg2cffi (>=2.9.0)"]
 s3 = ["botocore (>=1.28)", "s3fs (>=2022.4.0)"]
 snowflake = ["snowflake-connector-python (>=3.5.0)"]
+synapse = ["adlfs (>=2022.4.0)", "pyarrow (>=12.0.0)", "pyodbc (>=4.0.39,<5.0.0)"]
 weaviate = ["weaviate-client (>=3.22)"]
 
 [[package]]
@@ -2980,7 +2982,7 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8.1,<3.13"
-content-hash = "e6008802cc0b7a29b6c0612ce6360af11d3928665a34a5476869517ca239262d"
+content-hash = "373607ba2955222555af9ae89fd0a180c75de2225344b0f2a633204340c98aa7"
 
 [metadata.files]
 adlfs = [
@@ -3486,8 +3488,8 @@ decorator = [
     {file = "decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"},
 ]
 dlt = [
-    {file = "dlt-0.4.3a0-py3-none-any.whl", hash = "sha256:f6ece639d353c6239fa73465d948a623fda7b4448151e97e6a794ad551acb341"},
-    {file = "dlt-0.4.3a0.tar.gz", hash = "sha256:1b964243170cd44cffa98bb9e3455ad60aa7b3885f1d587bc76e86c95f5befa5"},
+    {file = "dlt-0.4.4-py3-none-any.whl", hash = "sha256:dfa1d0fd1ba5e2741f0d58314ca56aad26ec25032039bc3fa5d873d4611d8568"},
+    {file = "dlt-0.4.4.tar.gz", hash = "sha256:9a9619f78fe06cc157a23179b4fb17a059606e8c980756ea0652b167b91356fa"},
 ]
 dnspython = [
     {file = "dnspython-2.4.2-py3-none-any.whl", hash = "sha256:57c6fbaaeaaf39c891292012060beb141791735dbb4004798328fc2c467402d8"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = [{include = "sources"}]
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<3.13"
-dlt = {version = "0.4.3a0", allow-prereleases = true, extras = ["redshift", "bigquery", "postgres", "duckdb", "s3", "gs"]}
+dlt = {version = "0.4.4", allow-prereleases = true, extras = ["redshift", "bigquery", "postgres", "duckdb", "s3", "gs"]}
 
 [tool.poetry.group.dev.dependencies]
 mypy = "1.6.1"

--- a/sources/sql_database/__init__.py
+++ b/sources/sql_database/__init__.py
@@ -45,7 +45,7 @@ def sql_database(
         detect_precision_hints (bool): Set column precision and scale hints for supported data types in the target schema based on the columns in the source tables.
             This is disabled by default.
         defer_table_reflect (bool): Will connect and reflect table schema only when yielding data. Requires table_names to be explicitly passed.
-            Enable this option when running on Airflow. Available on dlt 0.4.3 and later.
+            Enable this option when running on Airflow. Available on dlt 0.4.4 and later.
         table_adapter_callback: (Callable): Receives each reflected table. May be used to modify the list of columns that will be selected.
     Returns:
         Iterable[DltResource]: A list of DLT resources for each table to be loaded.
@@ -117,7 +117,7 @@ def sql_table(
         detect_precision_hints (bool): Set column precision and scale hints for supported data types in the target schema based on the columns in the source tables.
             This is disabled by default.
         defer_table_reflect (bool): Will connect and reflect table schema only when yielding data. Enable this option when running on Airflow. Available
-            on dlt 0.4.3 and later
+            on dlt 0.4.4 and later
         table_adapter_callback: (Callable): Receives each reflected table. May be used to modify the list of columns that will be selected.
 
     Returns:

--- a/sources/sql_database/__init__.py
+++ b/sources/sql_database/__init__.py
@@ -1,6 +1,6 @@
 """Source that loads tables form any SQLAlchemy supported database, supports batching requests and incremental loads."""
 
-from typing import List, Optional, Union, Iterable, Any
+from typing import Callable, List, Optional, Union, Iterable, Any
 from sqlalchemy import MetaData, Table
 from sqlalchemy.engine import Engine
 
@@ -9,6 +9,7 @@ from dlt.sources import DltResource
 
 
 from dlt.sources.credentials import ConnectionStringCredentials
+from dlt.common.configuration.specs.config_section_context import ConfigSectionContext
 
 from .helpers import (
     table_rows,
@@ -26,7 +27,10 @@ def sql_database(
     schema: Optional[str] = dlt.config.value,
     metadata: Optional[MetaData] = None,
     table_names: Optional[List[str]] = dlt.config.value,
+    chunk_size: int = 1000,
     detect_precision_hints: Optional[bool] = dlt.config.value,
+    defer_table_reflect: Optional[bool] = dlt.config.value,
+    table_adapter_callback: Callable[[Table], None] = None,
 ) -> Iterable[DltResource]:
     """
     A DLT source which loads data from an SQL database using SQLAlchemy.
@@ -37,36 +41,56 @@ def sql_database(
         schema (Optional[str]): Name of the database schema to load (if different from default).
         metadata (Optional[MetaData]): Optional `sqlalchemy.MetaData` instance. `schema` argument is ignored when this is used.
         table_names (Optional[List[str]]): A list of table names to load. By default, all tables in the schema are loaded.
+        chunk_size (int): Number of rows yielded in one batch. SQL Alchemy will create additional internal rows buffer twice the chunk size.
         detect_precision_hints (bool): Set column precision and scale hints for supported data types in the target schema based on the columns in the source tables.
             This is disabled by default.
+        defer_table_reflect (bool): Will connect and reflect table schema only when yielding data. Requires table_names to be explicitly passed.
+            Enable this option when running on Airflow. Available on dlt 0.4.3 and later.
+        table_adapter_callback: (Callable): Receives each reflected table. May be used to modify the list of columns that will be selected.
     Returns:
         Iterable[DltResource]: A list of DLT resources for each table to be loaded.
     """
 
     # set up alchemy engine
     engine = engine_from_credentials(credentials)
-    engine.execution_options(stream_results=True)
+    engine.execution_options(stream_results=True, max_row_buffer=2 * chunk_size)
     metadata = metadata or MetaData(schema=schema)
 
     # use provided tables or all tables
     if table_names:
-        tables = [Table(name, metadata, autoload_with=engine) for name in table_names]
+        tables = [
+            Table(name, metadata, autoload_with=None if defer_table_reflect else engine)
+            for name in table_names
+        ]
     else:
+        if defer_table_reflect:
+            raise ValueError("You must pass table names to defer table reflection")
         metadata.reflect(bind=engine)
         tables = list(metadata.tables.values())
 
     for table in tables:
+        if table_adapter_callback and not defer_table_reflect:
+            table_adapter_callback(table)
         yield dlt.resource(
             table_rows,
             name=table.name,
             primary_key=get_primary_key(table),
             spec=SqlDatabaseTableConfiguration,
             columns=table_to_columns(table) if detect_precision_hints else None,
-        )(engine, table)
+        )(
+            engine,
+            table,
+            chunk_size,
+            detect_precision_hints=detect_precision_hints,
+            defer_table_reflect=defer_table_reflect,
+            table_adapter_callback=table_adapter_callback,
+        )
 
 
-@dlt.common.configuration.with_config(
-    sections=("sources", "sql_database"), spec=SqlTableResourceConfiguration
+@dlt.sources.config.with_config(
+    sections=("sources", "sql_database"),
+    spec=SqlTableResourceConfiguration,
+    sections_merge_style=ConfigSectionContext.resource_merge_style,
 )
 def sql_table(
     credentials: Union[ConnectionStringCredentials, Engine, str] = dlt.secrets.value,
@@ -74,7 +98,10 @@ def sql_table(
     schema: Optional[str] = dlt.config.value,
     metadata: Optional[MetaData] = None,
     incremental: Optional[dlt.sources.incremental[Any]] = None,
+    chunk_size: int = 1000,
     detect_precision_hints: Optional[bool] = dlt.config.value,
+    defer_table_reflect: Optional[bool] = dlt.config.value,
+    table_adapter_callback: Callable[[Table], None] = None,
 ) -> DltResource:
     """
     A dlt resource which loads data from an SQL database table using SQLAlchemy.
@@ -86,22 +113,37 @@ def sql_table(
         metadata (Optional[MetaData]): Optional `sqlalchemy.MetaData` instance. If provided, the `schema` argument is ignored.
         incremental (Optional[dlt.sources.incremental[Any]]): Option to enable incremental loading for the table.
             E.g., `incremental=dlt.sources.incremental('updated_at', pendulum.parse('2022-01-01T00:00:00Z'))`
-        write_disposition (str): Write disposition of the resource.
+        chunk_size (int): Number of rows yielded in one batch. SQL Alchemy will create additional internal rows buffer twice the chunk size.
         detect_precision_hints (bool): Set column precision and scale hints for supported data types in the target schema based on the columns in the source tables.
             This is disabled by default.
+        defer_table_reflect (bool): Will connect and reflect table schema only when yielding data. Enable this option when running on Airflow. Available
+            on dlt 0.4.3 and later
+        table_adapter_callback: (Callable): Receives each reflected table. May be used to modify the list of columns that will be selected.
 
     Returns:
         DltResource: The dlt resource for loading data from the SQL database table.
     """
     engine = engine_from_credentials(credentials)
-    engine.execution_options(stream_results=True)
+    engine.execution_options(stream_results=True, max_row_buffer=2 * chunk_size)
     metadata = metadata or MetaData(schema=schema)
 
-    table_obj = Table(table, metadata, autoload_with=engine)
+    table_obj = Table(
+        table, metadata, autoload_with=None if defer_table_reflect else engine
+    )
+    if table_adapter_callback and not defer_table_reflect:
+        table_adapter_callback(table_obj)
 
     return dlt.resource(
         table_rows,
         name=table_obj.name,
         primary_key=get_primary_key(table_obj),
         columns=table_to_columns(table_obj) if detect_precision_hints else None,
-    )(engine, table_obj, incremental=incremental)
+    )(
+        engine,
+        table_obj,
+        chunk_size,
+        incremental=incremental,
+        detect_precision_hints=detect_precision_hints,
+        defer_table_reflect=defer_table_reflect,
+        table_adapter_callback=table_adapter_callback,
+    )

--- a/sources/sql_database/settings.py
+++ b/sources/sql_database/settings.py
@@ -1,3 +1,0 @@
-"""Sql Database source settings and constants"""
-
-DEFAULT_CHUNK_SIZE = 1000

--- a/sources/sql_database_pipeline.py
+++ b/sources/sql_database_pipeline.py
@@ -2,9 +2,8 @@ from typing import Iterator, Any
 
 import dlt
 from dlt.sources.credentials import ConnectionStringCredentials
-from dlt.common import pendulum
 
-from sql_database import sql_database, sql_table
+from sql_database import sql_database, sql_table, Table
 
 
 def load_select_tables_from_database() -> None:
@@ -113,21 +112,19 @@ def select_columns() -> None:
         full_refresh=True,
     )
 
-    def table_adapter(table):
+    def table_adapter(table: Table) -> None:
         print(table.name)
         if table.name == "family":
             # this is SqlAlchemy table. _columns are writable
             # let's drop updated column
-            table._columns.remove(
-                table.columns["updated"]
-            )
+            table._columns.remove(table.columns["updated"])
 
     family = sql_table(
         credentials="mysql+pymysql://rfamro@mysql-rfam-public.ebi.ac.uk:4497/Rfam",
         table="family",
         chunk_size=10,
         detect_precision_hints=True,
-        table_adapter_callback=table_adapter
+        table_adapter_callback=table_adapter,
     )
 
     # also we do not want the whole table, so we add limit to get just one chunk (10 records)
@@ -213,6 +210,7 @@ if __name__ == "__main__":
     # Load selected tables with different settings
     # load_select_tables_from_database()
 
+    # load a table and select columns
     select_columns()
 
     # Load tables with the standalone table resource

--- a/sources/sql_database_pipeline.py
+++ b/sources/sql_database_pipeline.py
@@ -63,27 +63,79 @@ def load_entire_database() -> None:
 
 
 def load_standalone_table_resource() -> None:
-    """Load a few known tables with the standalone sql_table resource"""
+    """Load a few known tables with the standalone sql_table resource, request full schema and deferred
+    table reflection"""
     pipeline = dlt.pipeline(
-        pipeline_name="rfam_database", destination="postgres", dataset_name="rfam_data"
+        pipeline_name="rfam_database",
+        destination="duckdb",
+        dataset_name="rfam_data",
+        full_refresh=True,
     )
 
     # Load a table incrementally starting at a given date
     # Adding incremental via argument like this makes extraction more efficient
     # as only rows newer than the start date are fetched from the table
+    # we also use `detect_precision_hints` to get detailed column schema
+    # and defer_table_reflect to reflect schema only during execution
     family = sql_table(
+        credentials="mysql+pymysql://rfamro@mysql-rfam-public.ebi.ac.uk:4497/Rfam",
         table="family",
         incremental=dlt.sources.incremental(
-            "updated", initial_value=pendulum.DateTime(2022, 1, 1, 0, 0, 0)
+            "updated",
         ),
+        detect_precision_hints=True,
+        defer_table_reflect=True,
     )
+    # columns will be empty here due to defer_table_reflect set to True
+    print(family.compute_table_schema())
 
     # Load all data from another table
-    genome = sql_table(table="genome")
+    genome = sql_table(
+        credentials="mysql+pymysql://rfamro@mysql-rfam-public.ebi.ac.uk:4497/Rfam",
+        table="genome",
+        detect_precision_hints=True,
+        defer_table_reflect=True,
+    )
 
     # Run the resources together
     info = pipeline.extract([family, genome], write_disposition="merge")
     print(info)
+    # Show inferred columns
+    print(pipeline.default_schema.to_pretty_yaml())
+
+
+def select_columns() -> None:
+    """Uses table adapter callback to modify list of columns to be selected"""
+    pipeline = dlt.pipeline(
+        pipeline_name="rfam_database",
+        destination="duckdb",
+        dataset_name="rfam_data_cols",
+        full_refresh=True,
+    )
+
+    def table_adapter(table):
+        print(table.name)
+        if table.name == "family":
+            # this is SqlAlchemy table. _columns are writable
+            # let's drop updated column
+            table._columns.remove(
+                table.columns["updated"]
+            )
+
+    family = sql_table(
+        credentials="mysql+pymysql://rfamro@mysql-rfam-public.ebi.ac.uk:4497/Rfam",
+        table="family",
+        chunk_size=10,
+        detect_precision_hints=True,
+        table_adapter_callback=table_adapter
+    )
+
+    # also we do not want the whole table, so we add limit to get just one chunk (10 records)
+    pipeline.run(family.add_limit(1))
+    # only 10 rows
+    print(pipeline.last_trace.last_normalize_info)
+    # no "updated" column in "family" table
+    print(pipeline.default_schema.to_pretty_yaml())
 
 
 def reflect_and_connector_x() -> None:
@@ -159,7 +211,9 @@ def reflect_and_connector_x() -> None:
 
 if __name__ == "__main__":
     # Load selected tables with different settings
-    load_select_tables_from_database()
+    # load_select_tables_from_database()
+
+    select_columns()
 
     # Load tables with the standalone table resource
     # load_standalone_table_resource()


### PR DESCRIPTION
# Tell us what you do here
- [x] improving, documenting, or customizing an existing source (please link an issue or describe below)

# Relevant issue
Improvements to `sql_database`
1. reflect tables at runtime - best option for Airflow
2. table adapter callback - ie. to select columns to replicate
3. control buffer sizes in SqlAlchemy