### PR TITLE
[REST API source] adds function to check connection

### DIFF
--- a/sources/rest_api/__init__.py
+++ b/sources/rest_api/__init__.py
@@ -24,8 +24,9 @@ from dlt.common.schema.typing import (
     TWriteDisposition,
 )
 from dlt.extract.incremental import Incremental
-from dlt.extract.source import DltResource
+from dlt.extract.source import DltResource, DltSource
 from dlt.extract.typing import TTableHintTemplate
+from dlt.common import logger
 
 from .auth import BearerTokenAuth, AuthBase
 from .client import RESTClient
@@ -476,3 +477,14 @@ def find_resolved_params(endpoint_config: Endpoint) -> List[ResolvedParam]:
         if isinstance(value, ResolveConfig)
         or (isinstance(value, dict) and value.get("type") == "resolve")
     ]
+
+def check_connection(
+    source: DltSource,
+    *resource_names: list[str],
+) -> tuple[bool, str]:
+    try:
+        list(source.with_resources(*resource_names).add_limit(1))
+        return (True, "")
+    except Exception as e:
+        logger.error(f"Error checking connection: {e}")
+        return (False, str(e))


### PR DESCRIPTION
# Tell us what you do here

- [x] improving, documenting, or customizing an existing source (please link an issue or describe below)


# Relevant issue

issue #313 

# More PR info
This PR adds a convenience function to test whether a configuration can connect to the API endpoint.

### Possible usages
1. allows easy checking if credentials are correct. Especially when dlt is embedded and used as a fivetran-type data platform where pipeline users enter their credentials in some UI or config file.
2. provides a clear way to test authentication, especially in the absence of an [auth verification endpoint](https://docs.datadoghq.com/api/latest/authentication/)

See demo in `rest_api_pipeline.py` for ways of using this function.

### Disadvantages of current implementation strategy
Requires awareness of the developer that it yields from the source. If a call to `check_connection()` is part of a pipeline run, it must be used with a separate source object to avoid losing data.

I tried calling `copy.deepcopy` on the source argument, but it crashed with `RecursionError: maximum recursion depth exceeded`

### Alternatives
Implement `check_connection` as a method on a subclass of `DltSource`, e.g. `GenericApiSource`
