### PR TITLE
Rest API: Ends pagination if next page path is not in response.json()

### DIFF
--- a/sources/rest_api/paginators.py
+++ b/sources/rest_api/paginators.py
@@ -182,7 +182,10 @@ class JSONResponsePaginator(BaseNextUrlPaginator):
         self._records_accessor = create_nested_accessor(records_key)
 
     def update_state(self, response: Response):
-        self.next_reference = self._next_key_accessor(response.json())
+        try:
+            self.next_reference = self._next_key_accessor(response.json())
+        except KeyError:
+           self.next_reference = None
 
     def extract_records(self, response: Response) -> Any:
         return self._records_accessor(response.json())

--- a/sources/rest_api/paginators.py
+++ b/sources/rest_api/paginators.py
@@ -185,7 +185,7 @@ class JSONResponsePaginator(BaseNextUrlPaginator):
         try:
             self.next_reference = self._next_key_accessor(response.json())
         except KeyError:
-           self.next_reference = None
+            self.next_reference = None
 
     def extract_records(self, response: Response) -> Any:
         return self._records_accessor(response.json())


### PR DESCRIPTION
# Tell us what you do here

- [x] fixing a bug (please link a relevant bug report)

References #313 

# More PR info

The Workable API does not include the json path to the next page for the last page of the response. Thus, this PR catches such cases.