### PR TITLE
fix(Workable): use append write disposition for candidate subresources

### DIFF
--- a/sources/workable/__init__.py
+++ b/sources/workable/__init__.py
@@ -112,8 +112,8 @@ def workable_source(
         # A transformer functions that yield the activities and offers for each candidate.
         for sub_endpoint in DEFAULT_DETAILS["candidates"]:
             logging.info(
-                f"Loading additional data for 'candidates' from '{sub_endpoint}' in 'merge' mode."
+                f"Loading additional data for 'candidates' from '{sub_endpoint}' in 'append' mode."
             )
             yield candidates_resource | dlt.transformer(
-                name=f"candidates_{sub_endpoint}", write_disposition="merge"
+                name=f"candidates_{sub_endpoint}", write_disposition="append"
             )(_get_details)("candidates", sub_endpoint, "id")


### PR DESCRIPTION
# Tell us what you do here
Given that there's no primary key set for candidate sub-resources, we should just use `append`

- [ ] implementing verified source (please link a relevant issue labeled as `verified source`)
- [x] fixing a bug (please link a relevant bug report)
- [ ] improving, documenting, or customizing an existing source (please link an issue or describe below)
- [ ] anything else (please link an issue or describe below)

# Relevant issue

issue #

# More PR info
