### PR TITLE
[REST Source] renames default_paginator argument to paginator

### DIFF
--- a/sources/rest_api/__init__.py
+++ b/sources/rest_api/__init__.py
@@ -47,7 +47,7 @@ class AuthConfig(TypedDict, total=False):
 class ClientConfig(TypedDict, total=False):
     base_url: str
     auth: Optional[AuthConfig]
-    default_paginator: Optional[PaginatorType]
+    paginator: Optional[PaginatorType]
 
 
 class ResourceConfig(TypedDict, total=False):
@@ -173,7 +173,7 @@ def rest_api_source(config: RESTAPIConfig):
         pokemon_source = rest_api_source({
             "client": {
                 "base_url": "https://pokeapi.co/api/v2/",
-                "default_paginator": "json_links",
+                "paginator": "json_links",
             },
             "endpoints": {
                 "pokemon": {
@@ -625,7 +625,7 @@ def rest_api_resources_v2(client: RESTClient, *resources: EndpointResource):
         github_source = rest_api_resources_v2(
             Client(
                 base_url="https://api.github.com/repos/dlt-hub/dlt/",
-                default_paginator="header_links",
+                paginator="header_links",
                 auth=BearerTokenAuth(dlt.secrets["token"]),
             ),
             Resource(

--- a/sources/rest_api_pipeline.py
+++ b/sources/rest_api_pipeline.py
@@ -88,8 +88,8 @@ def load_github_legacy():
         {
             "client": {
                 "base_url": "https://api.github.com/repos/dlt-hub/dlt/",
-                # If you leave out the default_paginator, it will be inferred from the API:
-                # "default_paginator": "header_links",
+                # If you leave out the paginator, it will be inferred from the API:
+                # "paginator": "header_links",
                 "auth": {
                     "token": dlt.secrets["github_token"],
                 },
@@ -180,8 +180,8 @@ def load_pokemon():
         {
             "client": {
                 "base_url": "https://pokeapi.co/api/v2/",
-                # If you leave out the default_paginator, it will be inferred from the API:
-                # default_paginator: "json_links",
+                # If you leave out the paginator, it will be inferred from the API:
+                # paginator: "json_links",
             },
             "resource_defaults": {
                 "endpoint": {


### PR DESCRIPTION
# Tell us what you do here

- [x] improving, documenting, or customizing an existing source (please link an issue or describe below)

# Relevant issue

issue #313 

# More PR info
as discussed, this name appears to be clearer because not other key uses "default" and the class property is called "paginator".