### PR TITLE
[REST source] header_links can extract from responses without a records_path

### DIFF
--- a/tests/rest_api/conftest.py
+++ b/tests/rest_api/conftest.py
@@ -28,6 +28,9 @@ router = APIRouter(MOCK_BASE_URL)
 
 
 def serialize_page(records, page_number, total_pages, base_url, records_key="data"):
+    if records_key is None:
+        return json.dumps(records)
+
     response = {
         records_key: records,
         "page": page_number,
@@ -72,6 +75,10 @@ def paginate_response(request, records, page_size=10, records_key="data"):
 def mock_api_server():
     with requests_mock.Mocker() as m:
 
+        @router.get(r"/posts_no_key(\?page=\d+)?$")
+        def posts_no_key(request, context):
+            return paginate_response(request, generate_posts(), records_key=None)
+
         @router.get("/posts(\?page=\d+)?$")
         def posts(request, context):
             return paginate_response(request, generate_posts())
@@ -98,7 +105,9 @@ def mock_api_server():
 
         @router.get("/posts_under_a_different_key$")
         def posts_with_results_key(request, context):
-            return paginate_response(request, generate_posts(), records_key="many-results")
+            return paginate_response(
+                request, generate_posts(), records_key="many-results"
+            )
 
         router.register_routes(m)
 

--- a/tests/rest_api/test_rest_api_source_offline.py
+++ b/tests/rest_api/test_rest_api_source_offline.py
@@ -163,6 +163,35 @@ def test_posts_under_results_key(mock_api_server):
     ]
 
 
+def test_posts_without_key(mock_api_server):
+    mock_source = rest_api_source(
+        {
+            "client": {
+                "base_url": "https://api.example.com",
+                "paginator": "header_links",
+            },
+            "resources": [
+                {
+                    "name": "posts_no_key",
+                    "endpoint": {
+                        "path": "posts_no_key",
+                    },
+                },
+            ],
+        }
+    )
+
+    res = list(mock_source.with_resources("posts_no_key").add_limit(1))
+
+    assert res[:5] == [
+        {"id": 0, "title": "Post 0"},
+        {"id": 1, "title": "Post 1"},
+        {"id": 2, "title": "Post 2"},
+        {"id": 3, "title": "Post 3"},
+        {"id": 4, "title": "Post 4"},
+    ]
+
+
 @pytest.mark.skip
 def test_load_mock_api_typeddict_config(mock_api_server):
     pipeline = dlt.pipeline(


### PR DESCRIPTION
# Tell us what you do here

- [x] fixing a bug (please link a relevant bug report)

# Relevant issue

issue #313 

# More PR info
Before: responses without the necessity for a records_path such as `[{"id": 0, "attr": "foobar"}]` caused the following exception with the `header_links` paginator : 
```
  File "rest_api/client.py", line 148, in paginate
    yield extract_records(response)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'NoneType' object is not callable
```

## Before
<img width="1048" alt="Screenshot 2024-02-29 at 22 59 32" src="https://github.com/dlt-hub/verified-sources/assets/217980/01cb6e6a-dd56-49e5-b097-0eee96b51f46">

## After
<img width="1062" alt="Screenshot 2024-02-29 at 22 59 58" src="https://github.com/dlt-hub/verified-sources/assets/217980/227e02c6-e14d-4bca-a1a3-9f855ba4ea64">

 