### PR TITLE
hides sql alchemy generics

### DIFF
--- a/sources/sql_database/helpers.py
+++ b/sources/sql_database/helpers.py
@@ -2,12 +2,10 @@
 
 from typing import (
     Callable,
-    cast,
     Any,
     List,
     Optional,
     Iterator,
-    Dict,
     Union,
 )
 import operator
@@ -16,12 +14,11 @@ import dlt
 from dlt.sources.credentials import ConnectionStringCredentials
 from dlt.common.configuration.specs import BaseConfiguration, configspec
 from dlt.common.typing import TDataItem
-from .schema_types import table_to_columns
+
+from .schema_types import table_to_columns, Table, SelectAny
 
 from sqlalchemy import Table, create_engine
 from sqlalchemy.engine import Engine
-from sqlalchemy.sql import Select
-from sqlalchemy import Table
 
 
 class TableLoader:
@@ -48,7 +45,7 @@ class TableLoader:
             self.cursor_column = None
             self.last_value = None
 
-    def make_query(self) -> Select[Any]:
+    def make_query(self) -> SelectAny:
         table = self.table
         query = table.select()
         if not self.incremental:

--- a/sources/sql_database/schema_types.py
+++ b/sources/sql_database/schema_types.py
@@ -1,12 +1,20 @@
-from typing import Any, Optional
-
+from typing import Optional, Any, Type, TYPE_CHECKING
+from typing_extensions import TypeAlias
+from sqlalchemy import Table, Column, Select
 from sqlalchemy.sql import sqltypes
-from sqlalchemy import Table, Column
 
 from dlt.common.schema.typing import TColumnSchema, TTableSchemaColumns
 
+# optionally create generics with any so they can be imported by dlt importer
+if TYPE_CHECKING:
+    SelectAny: TypeAlias = Select[Any]
+    ColumnAny: TypeAlias = Column[Any]
+else:
+    SelectAny: TypeAlias = Type[Any]
+    ColumnAny: TypeAlias = Type[Any]
 
-def sqla_col_to_column_schema(sql_col: Column[Any]) -> Optional[TColumnSchema]:
+
+def sqla_col_to_column_schema(sql_col: ColumnAny) -> Optional[TColumnSchema]:
     """Infer dlt schema column type from an sqlalchemy type.
 
     Precision and scale is inferred from that types that support it,


### PR DESCRIPTION
# Tell us what you do here
Hides sql alchemy generic types so we can drop sql alchemy dep in `dlt` core