### PR TITLE
Remove upper bound on dlt dependency in Kafka source

### DIFF
--- a/sources/kafka/requirements.txt
+++ b/sources/kafka/requirements.txt
@@ -1,2 +1,2 @@
 confluent-kafka>=2.3.0
-dlt>=0.3.25,<0.4
+dlt>=0.3.25


### PR DESCRIPTION
### Tell us what you do here
- improving, documenting, or customizing an existing source (please link an issue or describe below)

### Short description

Unpin the dlt dependency for the Kafka source.

### Related Issues

- Fixes #414

### Additional Context
