### PR TITLE
Temp fix for duplicate query string params in URL-based paginators

### DIFF
--- a/sources/rest_api/paginators.py
+++ b/sources/rest_api/paginators.py
@@ -117,6 +117,9 @@ class BaseNextUrlPaginator(BasePaginator):
             if not parsed_url.scheme:
                 self.next_reference = urljoin(request.url, self.next_reference)
 
+            # XXX: Temp fix to avoid duplicate query params
+            request.params = {}
+
         request.url = self.next_reference
 
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Tell us what you do here

This is a temporary fix for the issue of duplication of query string parameters in URL-based paginators.