### PR TITLE
rest_api: allow JSON payload and custom headers

### DIFF
--- a/sources/rest_api/__init__.py
+++ b/sources/rest_api/__init__.py
@@ -187,6 +187,7 @@ def create_resources(
         endpoint_resource = endpoint_resource_map[resource_name]
         endpoint_config = cast(Endpoint, endpoint_resource.pop("endpoint"))
         request_params = endpoint_config.get("params", {})
+        request_json = endpoint_config.get("json", None)
         paginator = create_paginator(endpoint_config.get("paginator"))
 
         resolved_param: ResolvedParam = resolved_param_map[resource_name]
@@ -225,6 +226,7 @@ def create_resources(
                 method: HTTPMethodBasic,
                 path: str,
                 params: Dict[str, Any],
+                json: Optional[Dict[str, Any]],
                 paginator: Optional[BasePaginator],
                 data_selector: Optional[jsonpath.TJsonPath],
                 hooks: Optional[Dict[str, Any]],
@@ -241,6 +243,7 @@ def create_resources(
                     method=method,
                     path=path,
                     params=params,
+                    json=json,
                     paginator=paginator,
                     data_selector=data_selector,
                     hooks=hooks,
@@ -253,6 +256,7 @@ def create_resources(
                 method=endpoint_config.get("method", "get"),
                 path=endpoint_config.get("path"),
                 params=request_params,
+                json=request_json,
                 paginator=paginator,
                 data_selector=endpoint_config.get("data_selector") or data_selector,
                 hooks=hooks,

--- a/sources/rest_api/__init__.py
+++ b/sources/rest_api/__init__.py
@@ -208,6 +208,7 @@ def create_resources(
 
         client = RESTClient(
             base_url=client_config["base_url"],
+            headers=client_config.get("headers"),
             auth=create_auth(client_config.get("auth")),
             paginator=create_paginator(client_config.get("paginator")),
         )

--- a/sources/rest_api/typing.py
+++ b/sources/rest_api/typing.py
@@ -38,6 +38,7 @@ class SimpleTokenAuthConfig(TypedDict, total=False):
 
 class ClientConfig(TypedDict, total=False):
     base_url: str
+    headers: Optional[Dict[str, str]]
     auth: Optional[Union[SimpleTokenAuthConfig, AuthConfigBase]]
     paginator: Optional[PaginatorType]
 

--- a/tests/rest_api/source_configs.py
+++ b/tests/rest_api/source_configs.py
@@ -141,4 +141,13 @@ VALID_CONFIGS = [
             },
         ],
     },
+    {
+        "client": {
+            "base_url": "https://api.example.com",
+            "headers": {
+                "X-Test-Header": "test42",
+            },
+        },
+        "resources": ["users"],
+    },
 ]

--- a/tests/rest_api/test_configurations.py
+++ b/tests/rest_api/test_configurations.py
@@ -1,0 +1,14 @@
+import pytest
+
+from sources.rest_api import rest_api_source
+from .source_configs import VALID_CONFIGS, INVALID_CONFIGS
+
+@pytest.mark.parametrize("expected_message, exception, invalid_config", INVALID_CONFIGS)
+def test_invalid_configurations(expected_message, exception, invalid_config):
+    with pytest.raises(exception, match=expected_message):
+        rest_api_source(invalid_config)
+
+
+@pytest.mark.parametrize("valid_config", VALID_CONFIGS)
+def test_valid_configurations(valid_config):
+    rest_api_source(valid_config)

--- a/tests/rest_api/test_rest_api_source_offline.py
+++ b/tests/rest_api/test_rest_api_source_offline.py
@@ -13,7 +13,6 @@ from sources.rest_api import (
 )
 from sources.rest_api.paginators import BasePaginator
 
-from .source_configs import VALID_CONFIGS, INVALID_CONFIGS
 
 
 def test_load_mock_api(mock_api_server):
@@ -289,14 +288,3 @@ def test_load_mock_api_typeddict_config(mock_api_server):
 
     assert table_counts["posts"] == 100
     assert table_counts["post_comments"] == 5000
-
-
-@pytest.mark.parametrize("expected_message, exception, invalid_config", INVALID_CONFIGS)
-def test_invalid_configurations(expected_message, exception, invalid_config):
-    with pytest.raises(exception, match=expected_message):
-        rest_api_source(invalid_config)
-
-
-@pytest.mark.parametrize("valid_config", VALID_CONFIGS)
-def test_valid_configurations(valid_config):
-    rest_api_source(valid_config)


### PR DESCRIPTION
### Description

This PR updates rest_api source to allow specifying:
- JSON payload for non-dependent (parent) resources.
- Custom HTTP headers in the client config.