### PR TITLE
Use RESTClient in generic template

### DIFF
--- a/init/pipeline.py
+++ b/init/pipeline.py
@@ -33,6 +33,7 @@ def my_repo_pulls(
     for page in paginate(
         url,
         auth=BearerTokenAuth(api_secret_key),
+        # Note: for more paginators please see: https://dlthub.com/devel/general-usage/http/rest-client#paginators
         paginator=HeaderLinkPaginator(),
     ):
         print(page)

--- a/init/pipeline.py
+++ b/init/pipeline.py
@@ -12,14 +12,18 @@ from dlt.sources.helpers.rest_client.paginators import HeaderLinkPaginator
 
 
 @dlt.source
-def source(api_url: str = dlt.config.value, api_secret_key: str = dlt.secrets.value):
-    return my_repo_pulls(api_url, api_secret_key)
+def source(
+    api_url: str = dlt.config.value,
+    api_secret_key: str = dlt.secrets.value,
+    repository: str = dlt.config.value,
+):
+    return my_repo_pulls(api_url, api_secret_key, repository)
 
 
 @dlt.resource(write_disposition="append")
 def my_repo_pulls(
     api_url: str = dlt.config.value,
-    api_secret_key=dlt.secrets.value,
+    api_secret_key: str = dlt.secrets.value,
     repository: str = dlt.config.value,
 ):
     # repository url should be in the format `OWNER/REPO`

--- a/init/pipeline.py
+++ b/init/pipeline.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
     # otherwise the defaults will be used that are derived from the current script name
     pipeline = dlt.pipeline(
         pipeline_name="pipeline",
-        destination="bigquery",
+        destination="duckdb",
         dataset_name="pipeline_data",
     )
 

--- a/init/pipeline.py
+++ b/init/pipeline.py
@@ -4,11 +4,9 @@ from dlt.sources.helpers.rest_client import paginate
 from dlt.sources.helpers.rest_client.auth import BearerTokenAuth
 from dlt.sources.helpers.rest_client.paginators import HeaderLinkPaginator
 
-# This pipeline demonstrates how to use the dlt REST client for extracting data from the GitHub API.
-# It showcases the use of authentication via bearer tokens and pagination for navigating through
-# GitHub issues within a repository.
-
-# Note: Ensure the API key (Bearer token) is set up correctly in secrets or environment variables.
+# This is a generic pipeline example and demonstrates
+# how to use the dlt REST client for extracting data from APIs.
+# It showcases the use of authentication via bearer tokens and pagination.
 
 
 @dlt.source
@@ -17,23 +15,22 @@ def source(
     api_secret_key: str = dlt.secrets.value,
     repository: str = dlt.config.value,
 ):
-    return my_repo_issues(api_url, api_secret_key, repository)
+    return resource(api_url, api_secret_key, repository)
 
 
 @dlt.resource(write_disposition="append")
-def my_repo_issues(
-    api_url: str = dlt.config.value,
+def resource(
     api_secret_key: str = dlt.secrets.value,
-    repository: str = dlt.config.value,
+    org: str = "dlt-hub",
+    repository: str = "dlt",
 ):
-    # repository url should be in the format `OWNER/REPO`
-
     # paginate issues and yield every page
-    url = f"{api_url}/repos/{repository}/issues"
+    api_url = f"https://api.github.com/repos/{org}/{repository}/issues"
     for page in paginate(
-        url,
+        api_url,
         auth=BearerTokenAuth(api_secret_key),
-        # Note: for more paginators please see: https://dlthub.com/devel/general-usage/http/rest-client#paginators
+        # Note: for more paginators please see:
+        # https://dlthub.com/devel/general-usage/http/rest-client#paginators
         paginator=HeaderLinkPaginator(),
     ):
         print(page)
@@ -49,14 +46,13 @@ if __name__ == "__main__":
         dataset_name="pipeline_data",
     )
 
-    data = list(my_repo_issues())
+    data = list(resource())
 
     # print the data yielded from resource
     print(data)
-    exit()
 
     # run the pipeline with your parameters
-    load_info = pipeline.run(source())
+    # load_info = pipeline.run(source())
 
     # pretty print the information on data that was loaded
-    print(load_info)
+    # print(load_info)

--- a/init/pipeline.py
+++ b/init/pipeline.py
@@ -21,17 +21,37 @@ def resource(
     org: str = "dlt-hub",
     repository: str = "dlt",
 ):
+    yield [
+        {
+            "id": 1,
+            "node_id": "MDU6SXNzdWUx",
+            "number": 1347,
+            "state": "open",
+            "title": "Found a bug",
+            "body": "I'm having a problem with this.",
+            "user": {"login": "octocat", "id": 1},
+            "created_at": "2011-04-22T13:33:48Z",
+            "updated_at": "2011-04-22T13:33:48Z",
+            "repository": {
+                "id": 1296269,
+                "node_id": "MDEwOlJlcG9zaXRvcnkxMjk2MjY5",
+                "name": "Hello-World",
+                "full_name": "octocat/Hello-World",
+            },
+        }
+    ]
+
     # paginate issues and yield every page
-    api_url = f"https://api.github.com/repos/{org}/{repository}/issues"
-    for page in paginate(
-        api_url,
-        auth=BearerTokenAuth(api_secret_key),
-        # Note: for more paginators please see:
-        # https://dlthub.com/devel/general-usage/http/rest-client#paginators
-        paginator=HeaderLinkPaginator(),
-    ):
-        print(page)
-        yield page
+    # api_url = f"https://api.github.com/repos/{org}/{repository}/issues"
+    # for page in paginate(
+    #     api_url,
+    #     auth=BearerTokenAuth(api_secret_key),
+    #     # Note: for more paginators please see:
+    #     # https://dlthub.com/devel/general-usage/http/rest-client#paginators
+    #     paginator=HeaderLinkPaginator(),
+    # ):
+    #     # print(page)
+    #     yield page
 
 
 if __name__ == "__main__":

--- a/init/pipeline.py
+++ b/init/pipeline.py
@@ -4,7 +4,7 @@ from dlt.sources.helpers.rest_client import paginate
 from dlt.sources.helpers.rest_client.auth import BearerTokenAuth
 from dlt.sources.helpers.rest_client.paginators import HeaderLinkPaginator
 
-# This pipeline demonstrates how to build a simple REST client for interacting with GitHub's API.
+# This pipeline demonstrates how to use the dlt REST client for extracting data from the GitHub API.
 # It showcases the use of authentication via bearer tokens and pagination for navigating through
 # GitHub issues and pull requests within a repository.
 

--- a/init/pipeline.py
+++ b/init/pipeline.py
@@ -6,7 +6,7 @@ from dlt.sources.helpers.rest_client.paginators import HeaderLinkPaginator
 
 # This pipeline demonstrates how to use the dlt REST client for extracting data from the GitHub API.
 # It showcases the use of authentication via bearer tokens and pagination for navigating through
-# GitHub issues and pull requests within a repository.
+# GitHub issues within a repository.
 
 # Note: Ensure the API key (Bearer token) is set up correctly in secrets or environment variables.
 
@@ -17,19 +17,19 @@ def source(
     api_secret_key: str = dlt.secrets.value,
     repository: str = dlt.config.value,
 ):
-    return my_repo_pulls(api_url, api_secret_key, repository)
+    return my_repo_issues(api_url, api_secret_key, repository)
 
 
 @dlt.resource(write_disposition="append")
-def my_repo_pulls(
+def my_repo_issues(
     api_url: str = dlt.config.value,
     api_secret_key: str = dlt.secrets.value,
     repository: str = dlt.config.value,
 ):
     # repository url should be in the format `OWNER/REPO`
 
-    # paginate pull requests and yield every page
-    url = f"{api_url}/repos/{repository}/pulls"
+    # paginate issues and yield every page
+    url = f"{api_url}/repos/{repository}/issues"
     for page in paginate(
         url,
         auth=BearerTokenAuth(api_secret_key),
@@ -49,7 +49,7 @@ if __name__ == "__main__":
         dataset_name="pipeline_data",
     )
 
-    data = list(my_repo_pulls())
+    data = list(my_repo_issues())
 
     # print the data yielded from resource
     print(data)

--- a/init/pipeline.py
+++ b/init/pipeline.py
@@ -25,7 +25,7 @@ def my_repo_pulls(
     # repository url should be in the format `OWNER/REPO`
 
     # paginate pull requests and yield every page
-    url = f"{api_url}/{repository}/pulls"
+    url = f"{api_url}/repos/{repository}/pulls"
     for page in paginate(
         url,
         auth=BearerTokenAuth(api_secret_key),

--- a/init/pipeline.py
+++ b/init/pipeline.py
@@ -1,7 +1,7 @@
 import dlt
 
+from dlt.sources.helpers.rest_client import paginate
 from dlt.sources.helpers.rest_client.auth import BearerTokenAuth
-from dlt.sources.helpers.rest_client.client import RESTClient
 from dlt.sources.helpers.rest_client.paginators import HeaderLinkPaginator
 
 # This pipeline demonstrates how to build a simple REST client for interacting with GitHub's API.
@@ -24,16 +24,14 @@ def my_repo_pulls(
 ):
     # repository url should be in the format `OWNER/REPO`
 
-    # Build rest client instance
-    client = RESTClient(
-        base_url=f"{api_url}/repos",
+    # paginate pull requests and yield every page
+    url = f"{api_url}/{repository}/pulls"
+    for page in paginate(
+        url,
         auth=BearerTokenAuth(api_secret_key),
         paginator=HeaderLinkPaginator(),
-    )
-
-    # paginate pull requests and yield every page
-    url = f"/{repository}/pulls"
-    for page in client.paginate(url):
+    ):
+        print(page)
         yield page
 
 

--- a/init/pipeline.py
+++ b/init/pipeline.py
@@ -21,6 +21,7 @@ def resource(
     org: str = "dlt-hub",
     repository: str = "dlt",
 ):
+    # this is the test data for loading validation, delete it once you yield actual data
     yield [
         {
             "id": 1,

--- a/init/pipeline.py
+++ b/init/pipeline.py
@@ -10,12 +10,9 @@ from dlt.sources.helpers.rest_client.paginators import HeaderLinkPaginator
 
 
 @dlt.source
-def source(
-    api_url: str = dlt.config.value,
-    api_secret_key: str = dlt.secrets.value,
-    repository: str = dlt.config.value,
-):
-    return resource(api_url, api_secret_key, repository)
+def source(api_secret_key: str = dlt.secrets.value):
+    # print(f"api_secret_key={api_secret_key}")
+    return resource(api_secret_key)
 
 
 @dlt.resource(write_disposition="append")

--- a/init/pipeline.py
+++ b/init/pipeline.py
@@ -4,6 +4,12 @@ from dlt.sources.helpers.rest_client.auth import BearerTokenAuth
 from dlt.sources.helpers.rest_client.client import RESTClient
 from dlt.sources.helpers.rest_client.paginators import HeaderLinkPaginator
 
+# This pipeline demonstrates how to build a simple REST client for interacting with GitHub's API.
+# It showcases the use of authentication via bearer tokens and pagination for navigating through
+# GitHub issues and pull requests within a repository.
+
+# Note: Ensure the API key (Bearer token) is set up correctly in secrets or environment variables.
+
 
 @dlt.source
 def source(api_url: str = dlt.config.value, api_secret_key: str = dlt.secrets.value):

--- a/init/pipeline_generic.py
+++ b/init/pipeline_generic.py
@@ -30,14 +30,10 @@ def resource_1(
         base_url=api_url,
         auth=BearerTokenAuth(api_secret_key),
     )
-    response = client.get(
-        "/",
-        params={"query": explicit_arg},
-    )
 
-    # yield a list of items
-    data = response.json()
-    yield data["items"]
+    # yield page by page
+    for page in client.paginate(params={"query": explicit_arg}):
+        yield page["items"]
 
 
 @dlt.resource
@@ -49,15 +45,10 @@ def resource_2(
         base_url=api_url,
         auth=BearerTokenAuth(api_secret_key),
     )
-    response = client.get(
-        "/",
-        params={"last_value": default_arg},
-    )
 
     # yield item by item
-    data = response.json()
-    for value in data["data"]:
-        yield value
+    for page in client.paginate(params={"query": default_arg}):
+        yield page["data"]
 
 
 if __name__ == "__main__":

--- a/init/pipeline_generic.py
+++ b/init/pipeline_generic.py
@@ -1,71 +1,87 @@
+from typing import Any, Dict, Optional
 import dlt
 
 from dlt.sources.helpers.rest_client.auth import BearerTokenAuth
 from dlt.sources.helpers.rest_client.client import RESTClient
-from dlt.sources.helpers.rest_client.paginators import JSONResponsePaginator
+from dlt.sources.helpers.rest_client.paginators import HeaderLinkPaginator
 
+
+# Note: Ensure the API key (Bearer token) is set up correctly in secrets or environment variables.
 
 @dlt.source
 def source(
-    explicit_arg,
     api_url=dlt.config.value,
     api_secret_key=dlt.secrets.value,
-    default_arg="default",
+    issues_params: Optional[Dict[str, Any]] = None,
+    pulls_params: Optional[Dict[str, Any]] = None,
 ):
-    # as an example this source groups two resources that will be loaded together
-    return resource_1(explicit_arg, api_url, api_secret_key), resource_2(
-        api_url, api_secret_key, default_arg=default_arg
-    )
+    """This source function aggregates data from two GitHub endpoints: issues and pull requests."""
+    # Ensure that both the API URL and secret key are provided for GitHub
+    # either via secrets.toml or via environment variables.
+    return [
+        dlt_repo_issues(api_url, api_secret_key, params=issues_params),
+        dlt_repo_pulls(api_url, api_secret_key, params=pulls_params),
+    ]
 
 
 @dlt.resource
-def resource_1(
-    explicit_arg, api_url=dlt.config.value, api_secret_key=dlt.secrets.value
+def dlt_repo_issues(
+    api_url: str = dlt.config.value,
+    api_secret_key: str = dlt.secrets.value,
+    repository: str = dlt.config.value,
+    params: Optional[Dict[str, Any]] = None,
 ):
-    # uncomment line below to see if your headers are correct (ie. include valid api_key)
-    # print(headers)
-    # print(api_url)
+    """
+    Fetches issues from a specified repository on GitHub using Bearer Token Authentication.
+    """
+    # repository url should be in the format `OWNER/REPO`
 
     # Build rest client instance
     client = RESTClient(
-        base_url=api_url,
+        base_url=f"{api_url}/repos",
         auth=BearerTokenAuth(api_secret_key),
-        paginator=JSONResponsePaginator(next_url_path="next"),
+        paginator=HeaderLinkPaginator(),
     )
 
-    # yield page by page
-    for page in client.paginate(params={"query": explicit_arg}):
-        yield page["items"]
+    # paginate issues and yield every page
+    url = f"/{repository}/issues"
+    for page in client.paginate(url, params=params):
+        yield page
 
 
 @dlt.resource
-def resource_2(
-    api_url=dlt.config.value, api_secret_key=dlt.secrets.value, default_arg="default"
+def dlt_repo_pulls(
+    api_url: str = dlt.config.value,
+    api_secret_key: str = dlt.secrets.value,
+    repository: str = dlt.config.value,
+    params: Optional[Dict[str, Any]] = None,
 ):
+    # repository url should be in the format `OWNER/REPO`
+
     # Build rest client instance
     client = RESTClient(
-        base_url=api_url,
+        base_url=f"{api_url}/repos",
         auth=BearerTokenAuth(api_secret_key),
+        paginator=HeaderLinkPaginator(),
     )
 
-    # yield item by item
-    for page in client.paginate(params={"query": default_arg}):
-        yield page["data"]
+    # paginate pull requests and yield every page
+    url = f"/{repository}/pulls"
+    for page in client.paginate(url, params=params):
+        yield page
 
 
 if __name__ == "__main__":
-    # specify the pipeline name, destination and dataset name when configuring pipeline, otherwise the defaults will be used that are derived from the current script name
+    # specify the pipeline name, destination and dataset name when configuring pipeline,
+    # otherwise the defaults will be used that are derived from the current script name
     p = dlt.pipeline(
         pipeline_name="generic",
-        destination="bigquery",
+        destination="duckdb",
         dataset_name="generic_data",
         full_refresh=False,
     )
 
-    # uncomment line below to execute the resource function and see the returned data
-    # print(list(resource_1("term")))
+    load_info = p.run(source(pulls_params={"state": "open"}))
 
-    # explain that api_key will be automatically loaded from secrets.toml or environment variable below
-    load_info = p.run(source("term", default_arg="last_value"))
     # pretty print the information on data that was loaded
     print(load_info)

--- a/init/pipeline_generic.py
+++ b/init/pipeline_generic.py
@@ -1,11 +1,7 @@
 import dlt
-from dlt.sources.helpers import requests
 
-
-def _create_auth_headers(api_secret_key):
-    """Constructs Bearer type authorization header which is the most common authorization method"""
-    headers = {"Authorization": f"Bearer {api_secret_key}"}
-    return headers
+from dlt.sources.helpers.rest_client.client import RESTClient
+from dlt.sources.helpers.rest_client.auth import BearerTokenAuth
 
 
 @dlt.source
@@ -25,19 +21,22 @@ def source(
 def resource_1(
     explicit_arg, api_url=dlt.config.value, api_secret_key=dlt.secrets.value
 ):
-    headers = _create_auth_headers(api_secret_key)
-
     # uncomment line below to see if your headers are correct (ie. include valid api_key)
     # print(headers)
     # print(api_url)
 
-    # make a call to the endpoint with request library
-    resp = requests.get("%s?query=%s" % (api_url, explicit_arg), headers=headers)
-    resp.raise_for_status()
-    # yield the data from the resource
-    data = resp.json()
+    # Build rest client instance
+    client = RESTClient(
+        base_url=api_url,
+        auth=BearerTokenAuth(api_secret_key),
+    )
+    response = client.get(
+        "/",
+        params={"query": explicit_arg},
+    )
 
     # yield a list of items
+    data = response.json()
     yield data["items"]
 
 
@@ -45,15 +44,18 @@ def resource_1(
 def resource_2(
     api_url=dlt.config.value, api_secret_key=dlt.secrets.value, default_arg="default"
 ):
-    headers = _create_auth_headers(api_secret_key)
-
-    # make a call to the endpoint with request library
-    resp = requests.get("%s?last_value=%s" % (api_url, default_arg), headers=headers)
-    resp.raise_for_status()
-    # yield the data from the resource
-    data = resp.json()
+    # Build rest client instance
+    client = RESTClient(
+        base_url=api_url,
+        auth=BearerTokenAuth(api_secret_key),
+    )
+    response = client.get(
+        "/",
+        params={"last_value": default_arg},
+    )
 
     # yield item by item
+    data = response.json()
     for value in data["data"]:
         yield value
 

--- a/init/pipeline_generic.py
+++ b/init/pipeline_generic.py
@@ -2,8 +2,8 @@ from typing import Any, Dict, Optional
 
 import dlt
 
+from dlt.sources.helpers.rest_client import paginate
 from dlt.sources.helpers.rest_client.auth import BearerTokenAuth
-from dlt.sources.helpers.rest_client.client import RESTClient
 from dlt.sources.helpers.rest_client.paginators import HeaderLinkPaginator
 
 # This pipeline demonstrates how to build a simple REST client for interacting with GitHub's API.
@@ -41,16 +41,15 @@ def my_repo_issues(
     """
     # repository url should be in the format `OWNER/REPO`
 
-    # Build rest client instance
-    client = RESTClient(
-        base_url=f"{api_url}/repos",
+    # paginate issues and yield every page
+    url = f"{api_url}/repos/{repository}/issues"
+    for page in paginate(
+        url,
+        params=params,
         auth=BearerTokenAuth(api_secret_key),
         paginator=HeaderLinkPaginator(),
-    )
-
-    # paginate issues and yield every page
-    url = f"/{repository}/issues"
-    for page in client.paginate(url, params=params):
+    ):
+        print(page)
         yield page
 
 
@@ -63,16 +62,15 @@ def my_repo_pulls(
 ):
     # repository url should be in the format `OWNER/REPO`
 
-    # Build rest client instance
-    client = RESTClient(
-        base_url=f"{api_url}/repos",
+    # paginate pull requests and yield every page
+    url = f"{api_url}/repos/{repository}/pulls"
+    for page in paginate(
+        url,
+        params=params,
         auth=BearerTokenAuth(api_secret_key),
         paginator=HeaderLinkPaginator(),
-    )
-
-    # paginate pull requests and yield every page
-    url = f"/{repository}/pulls"
-    for page in client.paginate(url, params=params):
+    ):
+        print(page)
         yield page
 
 

--- a/init/pipeline_generic.py
+++ b/init/pipeline_generic.py
@@ -18,8 +18,9 @@ def source(
     """This source function aggregates data from two GitHub endpoints: issues and pull requests."""
     # Ensure that secret key is provided for GitHub
     # either via secrets.toml or via environment variables.
+    # print(f"api_secret_key={api_secret_key}")
+
     api_url = f"https://api.github.com/repos/{org}/{repository}/pulls"
-    print(f"api_secret_key={api_secret_key}")
     return [
         resource_1(api_url, api_secret_key).add_limit(1),
         resource_2(api_url, api_secret_key).add_limit(1),

--- a/init/pipeline_generic.py
+++ b/init/pipeline_generic.py
@@ -1,7 +1,8 @@
 import dlt
 
-from dlt.sources.helpers.rest_client.client import RESTClient
 from dlt.sources.helpers.rest_client.auth import BearerTokenAuth
+from dlt.sources.helpers.rest_client.client import RESTClient
+from dlt.sources.helpers.rest_client.paginators import JSONResponsePaginator
 
 
 @dlt.source
@@ -29,6 +30,7 @@ def resource_1(
     client = RESTClient(
         base_url=api_url,
         auth=BearerTokenAuth(api_secret_key),
+        paginator=JSONResponsePaginator(next_url_path="next"),
     )
 
     # yield page by page

--- a/init/pipeline_generic.py
+++ b/init/pipeline_generic.py
@@ -22,8 +22,8 @@ def source(
 
     api_url = f"https://api.github.com/repos/{org}/{repository}"
     return [
-        resource_1(api_url, api_secret_key).add_limit(1),
-        resource_2(api_url, api_secret_key).add_limit(1),
+        resource_1(api_url, api_secret_key),
+        resource_2(api_url, api_secret_key),
     ]
 
 

--- a/init/pipeline_generic.py
+++ b/init/pipeline_generic.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, Optional
+
 import dlt
 
 from dlt.sources.helpers.rest_client.auth import BearerTokenAuth
@@ -23,13 +24,13 @@ def source(
     # Ensure that both the API URL and secret key are provided for GitHub
     # either via secrets.toml or via environment variables.
     return [
-        dlt_repo_issues(api_url, api_secret_key, params=issues_params),
-        dlt_repo_pulls(api_url, api_secret_key, params=pulls_params),
+        my_repo_issues(api_url, api_secret_key, params=issues_params),
+        my_repo_pulls(api_url, api_secret_key, params=pulls_params),
     ]
 
 
 @dlt.resource
-def dlt_repo_issues(
+def my_repo_issues(
     api_url: str = dlt.config.value,
     api_secret_key: str = dlt.secrets.value,
     repository: str = dlt.config.value,
@@ -54,7 +55,7 @@ def dlt_repo_issues(
 
 
 @dlt.resource
-def dlt_repo_pulls(
+def my_repo_pulls(
     api_url: str = dlt.config.value,
     api_secret_key: str = dlt.secrets.value,
     repository: str = dlt.config.value,

--- a/init/pipeline_generic.py
+++ b/init/pipeline_generic.py
@@ -5,8 +5,12 @@ from dlt.sources.helpers.rest_client.auth import BearerTokenAuth
 from dlt.sources.helpers.rest_client.client import RESTClient
 from dlt.sources.helpers.rest_client.paginators import HeaderLinkPaginator
 
+# This pipeline demonstrates how to build a simple REST client for interacting with GitHub's API.
+# It showcases the use of authentication via bearer tokens and pagination for navigating through
+# GitHub issues and pull requests within a repository.
 
 # Note: Ensure the API key (Bearer token) is set up correctly in secrets or environment variables.
+
 
 @dlt.source
 def source(

--- a/init/pipeline_generic.py
+++ b/init/pipeline_generic.py
@@ -20,7 +20,7 @@ def source(
     # either via secrets.toml or via environment variables.
     # print(f"api_secret_key={api_secret_key}")
 
-    api_url = f"https://api.github.com/repos/{org}/{repository}/pulls"
+    api_url = f"https://api.github.com/repos/{org}/{repository}"
     return [
         resource_1(api_url, api_secret_key).add_limit(1),
         resource_2(api_url, api_secret_key).add_limit(1),
@@ -34,7 +34,7 @@ def resource_1(api_url: str, api_secret_key: str = dlt.secrets.value):
     """
     # paginate issues and yield every page
     for page in paginate(
-        api_url,
+        f"{api_url}/issues",
         auth=BearerTokenAuth(api_secret_key),
         paginator=HeaderLinkPaginator(),
     ):
@@ -45,7 +45,7 @@ def resource_1(api_url: str, api_secret_key: str = dlt.secrets.value):
 @dlt.resource
 def resource_2(api_url: str, api_secret_key: str = dlt.secrets.value):
     for page in paginate(
-        api_url,
+        f"{api_url}/pulls",
         auth=BearerTokenAuth(api_secret_key),
         paginator=HeaderLinkPaginator(),
     ):


### PR DESCRIPTION
This PR updates `pipeline_generic` to use `RESTClient` to make requests.

Resolves: https://github.com/dlt-hub/verified-sources/issues/448