### PR TITLE
kafka: don't subscribe after consumer has been assigned

### DIFF
--- a/sources/kafka/__init__.py
+++ b/sources/kafka/__init__.py
@@ -79,7 +79,6 @@ def kafka_consumer(
         start_from = ensure_pendulum_datetime(start_from)
 
     tracker = OffsetTracker(consumer, topics, dlt.current.resource_state(), start_from)
-    consumer.subscribe(topics)
 
     # read messages up to the maximum offsets,
     # not waiting for new messages


### PR DESCRIPTION


<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Tell us what you do here
- fixing a bug (please link a relevant bug report)

### Short description

See #450.

Don't subscribe after assigning partitions and offsets.

### Related Issues

- Fixes #450

### Additional Context

