### PR TITLE
Updates resource base  config in rest api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ lint-dlt-init:
 lint-code:
 	./check-package.sh
 	poetry run mypy --config-file mypy.ini ./sources
+	# poetry run mypy --config-file mypy.ini ./tests/rest_api
 	poetry run mypy --config-file mypy.ini ./tools
 	poetry run flake8 --max-line-length=200 --extend-ignore=W503 sources init --show-source
 	poetry run flake8 --max-line-length=200 --extend-ignore=W503 tests --show-source

--- a/poetry.lock
+++ b/poetry.lock
@@ -1035,13 +1035,13 @@ files = [
 
 [[package]]
 name = "dlt"
-version = "0.4.11a0"
+version = "0.4.11a1"
 description = "dlt is an open-source python-first scalable data loading library that does not require any backend to run."
 optional = false
 python-versions = "<3.13,>=3.8.1"
 files = [
-    {file = "dlt-0.4.11a0-py3-none-any.whl", hash = "sha256:304f0a7a5b0bcd6da653d2ffc747b6dc9b3f5f3f1dfc1d78461711278b6026ed"},
-    {file = "dlt-0.4.11a0.tar.gz", hash = "sha256:ef475b8d895f186441a5b2c23c7f4aca3316fd627bbfd897af51632bb6e72da2"},
+    {file = "dlt-0.4.11a1-py3-none-any.whl", hash = "sha256:f5cdae4b6874aa8eb4b51e8a97752bc8a7f939213142b9f7e1cb0a6bc348e48e"},
+    {file = "dlt-0.4.11a1.tar.gz", hash = "sha256:c0869f58016a3fda7e486f86b6eacf026d51fe7c0894feb1552463445f84c189"},
 ]
 
 [package.dependencies]
@@ -6364,4 +6364,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.13"
-content-hash = "315e94904a07fca557107c023c095d77819919ef407266616381c16bd0d73c0d"
+content-hash = "5e4b0eec4d921600236d52a71a7dd16b9dc3f4dca3b46a6c5df659cfc5efbd2a"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1035,13 +1035,13 @@ files = [
 
 [[package]]
 name = "dlt"
-version = "0.4.10"
+version = "0.4.11a0"
 description = "dlt is an open-source python-first scalable data loading library that does not require any backend to run."
 optional = false
 python-versions = "<3.13,>=3.8.1"
 files = [
-    {file = "dlt-0.4.10-py3-none-any.whl", hash = "sha256:f9af939f1d9196489528c6ecbdc5a618f1a897d83cc9d52a8ab3bbeada836c64"},
-    {file = "dlt-0.4.10.tar.gz", hash = "sha256:e394443543f5038ba260b2932780cf9f5c82bc7ff2535e3b1752e8ca28b2cf61"},
+    {file = "dlt-0.4.11a0-py3-none-any.whl", hash = "sha256:304f0a7a5b0bcd6da653d2ffc747b6dc9b3f5f3f1dfc1d78461711278b6026ed"},
+    {file = "dlt-0.4.11a0.tar.gz", hash = "sha256:ef475b8d895f186441a5b2c23c7f4aca3316fd627bbfd897af51632bb6e72da2"},
 ]
 
 [package.dependencies]
@@ -2973,38 +2973,38 @@ files = [
 
 [[package]]
 name = "mypy"
-version = "1.6.1"
+version = "1.10.0"
 description = "Optional static typing for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mypy-1.6.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e5012e5cc2ac628177eaac0e83d622b2dd499e28253d4107a08ecc59ede3fc2c"},
-    {file = "mypy-1.6.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d8fbb68711905f8912e5af474ca8b78d077447d8f3918997fecbf26943ff3cbb"},
-    {file = "mypy-1.6.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21a1ad938fee7d2d96ca666c77b7c494c3c5bd88dff792220e1afbebb2925b5e"},
-    {file = "mypy-1.6.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b96ae2c1279d1065413965c607712006205a9ac541895004a1e0d4f281f2ff9f"},
-    {file = "mypy-1.6.1-cp310-cp310-win_amd64.whl", hash = "sha256:40b1844d2e8b232ed92e50a4bd11c48d2daa351f9deee6c194b83bf03e418b0c"},
-    {file = "mypy-1.6.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:81af8adaa5e3099469e7623436881eff6b3b06db5ef75e6f5b6d4871263547e5"},
-    {file = "mypy-1.6.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8c223fa57cb154c7eab5156856c231c3f5eace1e0bed9b32a24696b7ba3c3245"},
-    {file = "mypy-1.6.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8032e00ce71c3ceb93eeba63963b864bf635a18f6c0c12da6c13c450eedb183"},
-    {file = "mypy-1.6.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:4c46b51de523817a0045b150ed11b56f9fff55f12b9edd0f3ed35b15a2809de0"},
-    {file = "mypy-1.6.1-cp311-cp311-win_amd64.whl", hash = "sha256:19f905bcfd9e167159b3d63ecd8cb5e696151c3e59a1742e79bc3bcb540c42c7"},
-    {file = "mypy-1.6.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:82e469518d3e9a321912955cc702d418773a2fd1e91c651280a1bda10622f02f"},
-    {file = "mypy-1.6.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d4473c22cc296425bbbce7e9429588e76e05bc7342da359d6520b6427bf76660"},
-    {file = "mypy-1.6.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:59a0d7d24dfb26729e0a068639a6ce3500e31d6655df8557156c51c1cb874ce7"},
-    {file = "mypy-1.6.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:cfd13d47b29ed3bbaafaff7d8b21e90d827631afda134836962011acb5904b71"},
-    {file = "mypy-1.6.1-cp312-cp312-win_amd64.whl", hash = "sha256:eb4f18589d196a4cbe5290b435d135dee96567e07c2b2d43b5c4621b6501531a"},
-    {file = "mypy-1.6.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:41697773aa0bf53ff917aa077e2cde7aa50254f28750f9b88884acea38a16169"},
-    {file = "mypy-1.6.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7274b0c57737bd3476d2229c6389b2ec9eefeb090bbaf77777e9d6b1b5a9d143"},
-    {file = "mypy-1.6.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bbaf4662e498c8c2e352da5f5bca5ab29d378895fa2d980630656178bd607c46"},
-    {file = "mypy-1.6.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:bb8ccb4724f7d8601938571bf3f24da0da791fe2db7be3d9e79849cb64e0ae85"},
-    {file = "mypy-1.6.1-cp38-cp38-win_amd64.whl", hash = "sha256:68351911e85145f582b5aa6cd9ad666c8958bcae897a1bfda8f4940472463c45"},
-    {file = "mypy-1.6.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:49ae115da099dcc0922a7a895c1eec82c1518109ea5c162ed50e3b3594c71208"},
-    {file = "mypy-1.6.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8b27958f8c76bed8edaa63da0739d76e4e9ad4ed325c814f9b3851425582a3cd"},
-    {file = "mypy-1.6.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:925cd6a3b7b55dfba252b7c4561892311c5358c6b5a601847015a1ad4eb7d332"},
-    {file = "mypy-1.6.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8f57e6b6927a49550da3d122f0cb983d400f843a8a82e65b3b380d3d7259468f"},
-    {file = "mypy-1.6.1-cp39-cp39-win_amd64.whl", hash = "sha256:a43ef1c8ddfdb9575691720b6352761f3f53d85f1b57d7745701041053deff30"},
-    {file = "mypy-1.6.1-py3-none-any.whl", hash = "sha256:4cbe68ef919c28ea561165206a2dcb68591c50f3bcf777932323bc208d949cf1"},
-    {file = "mypy-1.6.1.tar.gz", hash = "sha256:4d01c00d09a0be62a4ca3f933e315455bde83f37f892ba4b08ce92f3cf44bcc1"},
+    {file = "mypy-1.10.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:da1cbf08fb3b851ab3b9523a884c232774008267b1f83371ace57f412fe308c2"},
+    {file = "mypy-1.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:12b6bfc1b1a66095ab413160a6e520e1dc076a28f3e22f7fb25ba3b000b4ef99"},
+    {file = "mypy-1.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e36fb078cce9904c7989b9693e41cb9711e0600139ce3970c6ef814b6ebc2b2"},
+    {file = "mypy-1.10.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:2b0695d605ddcd3eb2f736cd8b4e388288c21e7de85001e9f85df9187f2b50f9"},
+    {file = "mypy-1.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:cd777b780312ddb135bceb9bc8722a73ec95e042f911cc279e2ec3c667076051"},
+    {file = "mypy-1.10.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3be66771aa5c97602f382230165b856c231d1277c511c9a8dd058be4784472e1"},
+    {file = "mypy-1.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8b2cbaca148d0754a54d44121b5825ae71868c7592a53b7292eeb0f3fdae95ee"},
+    {file = "mypy-1.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1ec404a7cbe9fc0e92cb0e67f55ce0c025014e26d33e54d9e506a0f2d07fe5de"},
+    {file = "mypy-1.10.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e22e1527dc3d4aa94311d246b59e47f6455b8729f4968765ac1eacf9a4760bc7"},
+    {file = "mypy-1.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:a87dbfa85971e8d59c9cc1fcf534efe664d8949e4c0b6b44e8ca548e746a8d53"},
+    {file = "mypy-1.10.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:a781f6ad4bab20eef8b65174a57e5203f4be627b46291f4589879bf4e257b97b"},
+    {file = "mypy-1.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b808e12113505b97d9023b0b5e0c0705a90571c6feefc6f215c1df9381256e30"},
+    {file = "mypy-1.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f55583b12156c399dce2df7d16f8a5095291354f1e839c252ec6c0611e86e2e"},
+    {file = "mypy-1.10.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4cf18f9d0efa1b16478c4c129eabec36148032575391095f73cae2e722fcf9d5"},
+    {file = "mypy-1.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:bc6ac273b23c6b82da3bb25f4136c4fd42665f17f2cd850771cb600bdd2ebeda"},
+    {file = "mypy-1.10.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9fd50226364cd2737351c79807775136b0abe084433b55b2e29181a4c3c878c0"},
+    {file = "mypy-1.10.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f90cff89eea89273727d8783fef5d4a934be2fdca11b47def50cf5d311aff727"},
+    {file = "mypy-1.10.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fcfc70599efde5c67862a07a1aaf50e55bce629ace26bb19dc17cece5dd31ca4"},
+    {file = "mypy-1.10.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:075cbf81f3e134eadaf247de187bd604748171d6b79736fa9b6c9685b4083061"},
+    {file = "mypy-1.10.0-cp38-cp38-win_amd64.whl", hash = "sha256:3f298531bca95ff615b6e9f2fc0333aae27fa48052903a0ac90215021cdcfa4f"},
+    {file = "mypy-1.10.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fa7ef5244615a2523b56c034becde4e9e3f9b034854c93639adb667ec9ec2976"},
+    {file = "mypy-1.10.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3236a4c8f535a0631f85f5fcdffba71c7feeef76a6002fcba7c1a8e57c8be1ec"},
+    {file = "mypy-1.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a2b5cdbb5dd35aa08ea9114436e0d79aceb2f38e32c21684dcf8e24e1e92821"},
+    {file = "mypy-1.10.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:92f93b21c0fe73dc00abf91022234c79d793318b8a96faac147cd579c1671746"},
+    {file = "mypy-1.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:28d0e038361b45f099cc086d9dd99c15ff14d0188f44ac883010e172ce86c38a"},
+    {file = "mypy-1.10.0-py3-none-any.whl", hash = "sha256:f8c083976eb530019175aabadb60921e73b4f45736760826aa1689dda8208aee"},
+    {file = "mypy-1.10.0.tar.gz", hash = "sha256:3d087fcbec056c4ee34974da493a826ce316947485cef3901f511848e687c131"},
 ]
 
 [package.dependencies]
@@ -3015,6 +3015,7 @@ typing-extensions = ">=4.1.0"
 [package.extras]
 dmypy = ["psutil (>=4.0)"]
 install-types = ["pip"]
+mypyc = ["setuptools (>=50)"]
 reports = ["lxml"]
 
 [[package]]
@@ -6363,4 +6364,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.13"
-content-hash = "ae9798483262d3ecccae313723ac6b67fc416a71be8a3a7a467b78624950e0cc"
+content-hash = "315e94904a07fca557107c023c095d77819919ef407266616381c16bd0d73c0d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,11 @@ packages = [{include = "sources"}]
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<3.13"
-dlt = {version = "0.4.10", allow-prereleases = true, extras = ["redshift", "bigquery", "postgres", "duckdb"]}
+dlt = {version = "0.4.11a0", allow-prereleases = true, extras = ["redshift", "bigquery", "postgres", "duckdb"]}
 graphlib-backport = {version = "*", python = "<3.9"}
 
 [tool.poetry.group.dev.dependencies]
-mypy = "1.6.1"
+mypy = "^1.10.0"
 flake8 = "^6.0.0"
 pytest = "^7.2.0"
 bandit = "^1.7.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = [{include = "sources"}]
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<3.13"
-dlt = {version = "0.4.11a0", allow-prereleases = true, extras = ["redshift", "bigquery", "postgres", "duckdb"]}
+dlt = {version = "0.4.11a1", allow-prereleases = true, extras = ["redshift", "bigquery", "postgres", "duckdb"]}
 graphlib-backport = {version = "*", python = "<3.9"}
 
 [tool.poetry.group.dev.dependencies]

--- a/sources/filesystem/readers.py
+++ b/sources/filesystem/readers.py
@@ -28,7 +28,7 @@ def _read_csv(
         # Here we use pandas chunksize to read the file in chunks and avoid loading the whole file
         # in memory.
         with file_obj.open() as file:
-            for df in pd.read_csv(file, **kwargs):  # type: ignore[arg-type]
+            for df in pd.read_csv(file, **kwargs):
                 yield df.to_dict(orient="records")
 
 

--- a/sources/inbox/helpers.py
+++ b/sources/inbox/helpers.py
@@ -153,7 +153,7 @@ def extract_attachments(
         file_md = ImapFileItem(  # type: ignore
             file_name=part.get_filename(),
             mime_type=content_type,
-            file_content=part.get_payload(decode=True),
+            file_content=part.get_payload(decode=True),  # type: ignore[typeddict-item]
         )
         file_md["file_hash"] = hashlib.sha256(file_md["file_content"]).hexdigest()
         file_md["size_in_bytes"] = len(file_md["file_content"])
@@ -176,8 +176,8 @@ def get_email_body(msg: Message) -> str:
         for part in msg.walk():
             content_type = part.get_content_type()
             if content_type == "text/plain":
-                body += part.get_payload(decode=True).decode(errors="ignore")
+                body += part.get_payload(decode=True).decode(errors="ignore")  # type: ignore[union-attr]
     else:
-        body = msg.get_payload(decode=True).decode(errors="ignore")
+        body = msg.get_payload(decode=True).decode(errors="ignore")  # type: ignore[union-attr]
 
     return body

--- a/sources/pg_replication/__init__.py
+++ b/sources/pg_replication/__init__.py
@@ -82,7 +82,7 @@ def replication_resource(
     options = {"publication_names": pub_name, "proto_version": "1"}
     upto_lsn = get_max_lsn(slot_name, options, credentials)
     if upto_lsn is None:
-        return "Replication slot is empty."
+        return
 
     # generate items in batches
     while True:

--- a/sources/pg_replication/helpers.py
+++ b/sources/pg_replication/helpers.py
@@ -396,7 +396,7 @@ def get_max_lsn(
     """
     # comma-separated value string
     options_str = ", ".join(
-        f"'{x}'" for xs in list(map(list, options.items())) for x in xs  # type: ignore[arg-type]
+        f"'{x}'" for xs in list(map(list, options.items())) for x in xs
     )
     cur = _get_conn(credentials).cursor()
     cur.execute(

--- a/sources/rest_api/__init__.py
+++ b/sources/rest_api/__init__.py
@@ -83,7 +83,7 @@ def rest_api_source(
         pokemon_source = rest_api_source({
             "client": {
                 "base_url": "https://pokeapi.co/api/v2/",
-                "paginator": "json_links",
+                "paginator": "json_response",
             },
             "endpoints": {
                 "pokemon": {

--- a/sources/rest_api/__init__.py
+++ b/sources/rest_api/__init__.py
@@ -14,15 +14,15 @@ import graphlib  # type: ignore[import,unused-ignore]
 
 import dlt
 from dlt.common.validation import validate_dict
-from dlt.extract.incremental import Incremental
-from dlt.extract.source import DltResource, DltSource
 from dlt.common import jsonpath
 from dlt.common.schema.schema import Schema
 from dlt.common.schema.typing import TSchemaContract
 from dlt.common.configuration.specs import BaseConfiguration
 
+from dlt.extract.incremental import Incremental
+from dlt.extract.source import DltResource, DltSource
+
 from dlt.sources.helpers.rest_client import RESTClient
-from dlt.sources.helpers.rest_client.detector import single_entity_path
 from dlt.sources.helpers.rest_client.paginators import BasePaginator
 from dlt.sources.helpers.rest_client.typing import HTTPMethodBasic
 from .typing import (
@@ -174,13 +174,8 @@ def rest_api_resources(config: RESTAPIConfig) -> List[DltResource]:
     validate_dict(RESTAPIConfig, config, path=".")
 
     client_config = config["client"]
-
     resource_defaults = config.get("resource_defaults", {})
-
-    resource_list = config.get("resources")
-
-    if not resource_list:
-        raise ValueError("No resources defined")
+    resource_list = config["resources"]
 
     (
         dependency_graph,
@@ -242,12 +237,6 @@ def create_resources(
 
         hooks = create_response_hooks(endpoint_config.get("response_actions"))
 
-        # try to guess if list of entities or just single entity is returned
-        if single_entity_path(endpoint_config["path"]):
-            data_selector = "$"
-        else:
-            data_selector = None
-
         resource_kwargs = exclude_keys(
             endpoint_resource, {"endpoint", "include_from_parent"}
         )
@@ -290,12 +279,12 @@ def create_resources(
                 params=request_params,
                 json=request_json,
                 paginator=paginator,
-                data_selector=endpoint_config.get("data_selector") or data_selector,
+                data_selector=endpoint_config.get("data_selector"),
                 hooks=hooks,
             )
 
         else:
-            predecessor = resources[resolved_param.resolve_config.resource_name]
+            predecessor = resources[resolved_param.resolve_config["resource"]]
 
             base_params = exclude_keys(request_params, {resolved_param.param_name})
 
@@ -311,13 +300,13 @@ def create_resources(
                 resolved_param: ResolvedParam = resolved_param,
                 include_from_parent: List[str] = include_from_parent,
             ) -> Generator[Any, None, None]:
-                field_path = resolved_param.resolve_config.field_path
+                field_path = resolved_param.resolve_config["field"]
 
                 for item in items:
                     formatted_path = path.format(
                         **{resolved_param.param_name: item[field_path]}
                     )
-                    parent_resource_name = resolved_param.resolve_config.resource_name
+                    parent_resource_name = resolved_param.resolve_config["resource"]
 
                     parent_record = (
                         {
@@ -350,7 +339,7 @@ def create_resources(
                 path=endpoint_config.get("path"),
                 params=base_params,
                 paginator=paginator,
-                data_selector=endpoint_config.get("data_selector") or data_selector,
+                data_selector=endpoint_config.get("data_selector"),
                 hooks=hooks,
             )
 

--- a/sources/rest_api/config_setup.py
+++ b/sources/rest_api/config_setup.py
@@ -106,7 +106,7 @@ def create_paginator(
             return paginator_class() if paginator_class else None
         except TypeError:
             raise ValueError(
-                f"Paginator {paginator_config} requires arguments to create and instance. Use {paginator_class} instance instead."
+                f"Paginator {paginator_config} requires arguments to create an instance. Use {paginator_class} instance instead."
             )
 
     if isinstance(paginator_config, dict):

--- a/sources/rest_api/config_setup.py
+++ b/sources/rest_api/config_setup.py
@@ -94,12 +94,22 @@ def create_paginator(
 
     if isinstance(paginator_config, str):
         paginator_class = get_paginator_class(paginator_config)
-        return paginator_class()
+        try:
+            # auto has no associated class
+            return paginator_class() if paginator_class else None
+        except TypeError:
+            raise ValueError(
+                f"Paginator {paginator_config} requires arguments to create and instance. Use {paginator_class} instance instead."
+            )
 
     if isinstance(paginator_config, dict):
         paginator_type = paginator_config.get("type", "auto")
         paginator_class = get_paginator_class(paginator_type)
-        return paginator_class(**exclude_keys(paginator_config, {"type"}))
+        return (
+            paginator_class(**exclude_keys(paginator_config, {"type"}))
+            if paginator_class
+            else None
+        )
 
     return None
 

--- a/sources/rest_api/config_setup.py
+++ b/sources/rest_api/config_setup.py
@@ -102,7 +102,7 @@ def create_paginator(
     if isinstance(paginator_config, str):
         paginator_class = get_paginator_class(paginator_config)
         try:
-            # auto has no associated class
+            # `auto` has no associated class in `PAGINATOR_MAP`
             return paginator_class() if paginator_class else None
         except TypeError:
             raise ValueError(

--- a/sources/rest_api/config_setup.py
+++ b/sources/rest_api/config_setup.py
@@ -1,4 +1,4 @@
-import copy
+from copy import copy
 from typing import (
     Type,
     Any,
@@ -14,9 +14,14 @@ from typing import (
 import graphlib  # type: ignore[import,unused-ignore]
 
 import dlt
-from dlt.extract.incremental import Incremental
 from dlt.common import logger
 from dlt.common.configuration import resolve_configuration
+from dlt.common.schema.utils import merge_columns
+from dlt.common.utils import update_dict_nested
+
+from dlt.extract.incremental import Incremental
+from dlt.extract.utils import ensure_table_schema_columns
+
 from dlt.sources.helpers.requests import Response
 from dlt.sources.helpers.rest_client.paginators import (
     BasePaginator,
@@ -27,6 +32,7 @@ from dlt.sources.helpers.rest_client.paginators import (
     OffsetPaginator,
     PageNumberPaginator,
 )
+from dlt.sources.helpers.rest_client.detector import single_entity_path
 from dlt.sources.helpers.rest_client.exceptions import IgnoreResponseException
 from dlt.sources.helpers.rest_client.auth import (
     AuthConfigBase,
@@ -44,7 +50,8 @@ from .typing import (
     IncrementalArgs,
     IncrementalConfig,
     PaginatorConfig,
-    ResolveConfig,
+    ParamBindConfig,
+    ResolveParamConfig,
     ResolvedParam,
     ResponseAction,
     Endpoint,
@@ -126,55 +133,25 @@ def get_auth_class(auth_type: AuthType) -> Type[AuthConfigBase]:
 
 
 def create_auth(auth_config: Optional[AuthConfig]) -> Optional[AuthConfigBase]:
+    auth: AuthConfigBase = None
     if isinstance(auth_config, AuthConfigBase):
-        return auth_config
+        auth = auth_config
 
     if isinstance(auth_config, str):
         auth_class = get_auth_class(auth_config)
-        return resolve_configuration(auth_class())
+        auth = auth_class()
 
     if isinstance(auth_config, dict):
         auth_type = auth_config.get("type", "bearer")
         auth_class = get_auth_class(auth_type)
-        return resolve_configuration(auth_class(**exclude_keys(auth_config, {"type"})))
+        auth = auth_class(**exclude_keys(auth_config, {"type"}))
+
+    if auth:
+        # TODO: provide explicitly (non-default) values as explicit explicit_value=dict(auth)
+        # this will resolve auth which is a configuration using current section context
+        return resolve_configuration(auth)
 
     return None
-
-    # this will resolve auth which is a configuration using current section context
-
-    # # Handle a shorthand auth configuration
-    # if "token" in auth_config and len(auth_config) == 1:
-    #     return BearerTokenAuth(cast(TSecretStrValue, auth_config["token"]))
-
-    # # Handle full auth configurations
-    # auth_config = cast(AuthConfigBase, auth_config)
-    # if auth_config.get("type") == "http":
-    #     if auth_config.get("scheme") == "basic":
-    #         return HttpBasicAuth(
-    #             username=auth_config["username"], password=auth_config["password"]
-    #         )
-    #     elif auth_config.get("scheme") == "bearer":
-    #         return BearerTokenAuth(cast(TSecretStrValue, auth_config["token"]))
-    #     else:
-    #         raise ValueError(f"Invalid auth scheme: {auth_config['scheme']}")
-    # elif auth_config.get("type") == "apiKey":
-    #     return APIKeyAuth(
-    #         name=auth_config["name"],
-    #         api_key=cast(TSecretStrValue, auth_config["api_key"]),
-    #         location=auth_config.get("location"),
-    #     )
-    # elif auth_config.get("type") == "oauth2":
-    #     return OAuthJWTAuth(
-    #         client_id=auth_config["client_id"],
-    #         private_key=cast(TSecretStrValue, auth_config["private_key"]),
-    #         auth_endpoint=auth_config["auth_endpoint"],
-    #         scopes=auth_config["scopes"],
-    #         headers=auth_config.get("headers"),
-    #         private_key_passphrase=auth_config.get("private_key_passphrase"),
-    #         default_token_expiration=auth_config.get("default_token_expiration"),
-    #     )
-    # else:
-    #     raise ValueError(f"Invalid auth type: {auth_config['type']}")
 
 
 def setup_incremental_object(
@@ -186,6 +163,7 @@ def setup_incremental_object(
             return value, IncrementalParam(start=key, end=None)
         if isinstance(value, dict) and value.get("type") == "incremental":
             config = exclude_keys(value, {"type"})
+            # TODO: implement param type to bind incremental to
             return (
                 dlt.sources.incremental(**config),
                 IncrementalParam(start=key, end=None),
@@ -216,28 +194,31 @@ def build_resource_dependency_graph(
     resolved_param_map: Dict[str, ResolvedParam] = {}
 
     for resource_kwargs in resource_list:
-        endpoint_resource = make_endpoint_resource(resource_kwargs, resource_defaults)
+        if isinstance(resource_kwargs, dict):
+            # clone resource here, otherwise it needs to be cloned in several other places
+            # note that this clones only dict structure, keeping all instances without deepcopy
+            resource_kwargs = update_dict_nested({}, resource_kwargs)  # type: ignore[assignment]
+
+        endpoint_resource = _make_endpoint_resource(resource_kwargs, resource_defaults)
+        assert isinstance(endpoint_resource["endpoint"], dict)
+        _setup_single_entity_endpoint(endpoint_resource["endpoint"])
 
         resource_name = endpoint_resource["name"]
-
-        if not isinstance(resource_name, str):
-            raise ValueError(
-                f"Resource name must be a string, got {type(resource_name)}"
-            )
+        assert isinstance(
+            resource_name, str
+        ), f"Resource name must be a string, got {type(resource_name)}"
 
         if resource_name in endpoint_resource_map:
             raise ValueError(f"Resource {resource_name} has already been defined")
 
-        resolved_params = find_resolved_params(
-            cast(Endpoint, endpoint_resource["endpoint"])
-        )
-
+        # connect transformers to resources via resolved params
+        resolved_params = _find_resolved_params(endpoint_resource["endpoint"])
         if len(resolved_params) > 1:
             raise ValueError(
                 f"Multiple resolved params for resource {resource_name}: {resolved_params}"
             )
 
-        predecessors = set(x.resolve_config.resource_name for x in resolved_params)
+        predecessors = set(x.resolve_config["resource"] for x in resolved_params)
 
         dependency_graph.add(resource_name, *predecessors)
 
@@ -249,7 +230,7 @@ def build_resource_dependency_graph(
     return dependency_graph, endpoint_resource_map, resolved_param_map
 
 
-def make_endpoint_resource(
+def _make_endpoint_resource(
     resource: Union[str, EndpointResource], default_config: EndpointResourceBase
 ) -> EndpointResource:
     """
@@ -268,43 +249,46 @@ def make_endpoint_resource(
         resource = {"name": resource, "endpoint": {"path": resource}}
         return _merge_resource_endpoints(default_config, resource)
 
-    if "endpoint" in resource and isinstance(resource["endpoint"], str):
-        resource["endpoint"] = {"path": resource["endpoint"]}
-
-    if "name" not in resource:
-        raise ValueError("Resource must have a name")
+    if "endpoint" in resource:
+        if isinstance(resource["endpoint"], str):
+            resource["endpoint"] = {"path": resource["endpoint"]}
+    else:
+        # endpoint is optional
+        resource["endpoint"] = {}
 
     if "path" not in resource["endpoint"]:
         resource["endpoint"]["path"] = resource["name"]  # type: ignore
+
     return _merge_resource_endpoints(default_config, resource)
 
 
-def make_resolved_param(
-    key: str, value: Union[ResolveConfig, Dict[str, Any]]
-) -> Optional[ResolvedParam]:
-    if isinstance(value, ResolveConfig):
-        return ResolvedParam(key, value)
-    if isinstance(value, dict) and value.get("type") == "resolve":
-        return ResolvedParam(
-            key,
-            ResolveConfig(resource_name=value["resource"], field_path=value["field"]),
-        )
-    return None
+def _setup_single_entity_endpoint(endpoint: Endpoint) -> Endpoint:
+    """Tries to guess if the endpoint refers to a single entity and when detected:
+    * if `data_selector` was not specified (or is None), "$" is selected
+    * if `paginator` was not specified (or is None), SinglePagePaginator is selected
+
+    Endpoint is modified in place and returned
+    """
+    # try to guess if list of entities or just single entity is returned
+    if single_entity_path(endpoint["path"]):
+        if endpoint.get("data_selector") is None:
+            endpoint["data_selector"] = "$"
+        if endpoint.get("paginator") is None:
+            endpoint["paginator"] = SinglePagePaginator()
+    return endpoint
 
 
-def find_resolved_params(endpoint_config: Endpoint) -> List[ResolvedParam]:
+def _find_resolved_params(endpoint_config: Endpoint) -> List[ResolvedParam]:
     """
     Find all resolved params in the endpoint configuration and return
     a list of ResolvedParam objects.
 
-    Resolved params are either of type ResolveConfig or are dictionaries
-    with a key "type" set to "resolve".
+    Resolved params are of type ResolveParamConfig (bound param with a key "type" set to "resolve".)
     """
     return [
-        make_resolved_param(key, value)
+        ResolvedParam(key, value)  # type: ignore[arg-type]
         for key, value in endpoint_config.get("params", {}).items()
-        if isinstance(value, ResolveConfig)
-        or (isinstance(value, dict) and value.get("type") == "resolve")
+        if (isinstance(value, dict) and value.get("type") == "resolve")
     ]
 
 
@@ -379,9 +363,8 @@ def _merge_resource_endpoints(
     default_config: EndpointResourceBase, config: EndpointResource
 ) -> EndpointResource:
     """Merges `default_config` and `config`, returns new instance of EndpointResource"""
-    # merge endpoint, only params and json are allowed to deep merge
     # NOTE: config is normalized and always has "endpoint" field which is a dict
-    # NOTE: we could deep merge paginators and auths of the same type
+    # TODO: could deep merge paginators and auths of the same type
 
     default_endpoint = default_config.get("endpoint", Endpoint())
     assert isinstance(default_endpoint, dict)
@@ -392,6 +375,7 @@ def _merge_resource_endpoints(
         **default_endpoint,
         **{k: v for k, v in config_endpoint.items() if k not in ("json", "params")},  # type: ignore[typeddict-item]
     }
+    # merge endpoint, only params and json are allowed to deep merge
     if "json" in config_endpoint:
         merged_endpoint["json"] = {
             **(merged_endpoint.get("json", {})),
@@ -402,6 +386,22 @@ def _merge_resource_endpoints(
             **(merged_endpoint.get("json", {})),
             **config_endpoint["params"],
         }
+    # merge columns
+    if (default_columns := default_config.get("columns")) and (
+        columns := config.get("columns")
+    ):
+        # merge only native dlt formats, skip pydantic and others
+        if isinstance(columns, (list, dict)) and isinstance(
+            default_columns, (list, dict)
+        ):
+            # normalize columns
+            columns = ensure_table_schema_columns(columns)
+            default_columns = ensure_table_schema_columns(default_columns)
+            # merge columns with deep merging hints
+            config["columns"] = merge_columns(
+                copy(default_columns), columns, merge_columns=True
+            )
+
     # no need to deep merge resources
     merged_resource: EndpointResource = {
         **default_config,

--- a/sources/rest_api/exceptions.py
+++ b/sources/rest_api/exceptions.py
@@ -1,0 +1,8 @@
+from dlt.common.exceptions import DltException
+
+
+class RestApiException(DltException):
+    pass
+
+
+# class Paginator

--- a/sources/rest_api/typing.py
+++ b/sources/rest_api/typing.py
@@ -53,7 +53,7 @@ class PageNumberPaginatorConfig(PaginatorTypeConfig, total=False):
 class OffsetPaginatorConfig(PaginatorTypeConfig, total=False):
     """A paginator that uses offset-based pagination strategy."""
 
-    limit: Optional[int]
+    limit: int
     offset: Optional[int]
     offset_param: Optional[str]
     limit_param: Optional[str]

--- a/sources/rest_api/typing.py
+++ b/sources/rest_api/typing.py
@@ -21,7 +21,8 @@ from dlt.common.schema.typing import (
     TColumnNames,
     TTableFormat,
     TTableSchemaColumns,
-    TWriteDisposition,
+    TWriteDispositionConfig,
+    TSchemaContract,
 )
 
 PaginatorConfigDict = Dict[str, Any]
@@ -80,16 +81,25 @@ class Endpoint(TypedDict, total=False):
     incremental: Optional[IncrementalConfig]
 
 
-class EndpointResourceBase(TypedDict, total=False):
-    endpoint: Optional[Union[str, Endpoint]]
-    write_disposition: Optional[TTableHintTemplate[TWriteDisposition]]
+class ResourceBase(TypedDict, total=False):
+    """Defines hints that may be passed to `dlt.resource` decorator"""
+
+    table_name: Optional[TTableHintTemplate[str]]
+    max_table_nesting: Optional[int]
+    write_disposition: Optional[TTableHintTemplate[TWriteDispositionConfig]]
     parent: Optional[TTableHintTemplate[str]]
     columns: Optional[TTableHintTemplate[TTableSchemaColumns]]
     primary_key: Optional[TTableHintTemplate[TColumnNames]]
     merge_key: Optional[TTableHintTemplate[TColumnNames]]
+    schema_contract: Optional[TTableHintTemplate[TSchemaContract]]
     table_format: Optional[TTableHintTemplate[TTableFormat]]
-    include_from_parent: Optional[List[str]]
     selected: Optional[bool]
+    parallelized: Optional[bool]
+
+
+class EndpointResourceBase(ResourceBase, total=False):
+    endpoint: Optional[Union[str, Endpoint]]
+    include_from_parent: Optional[List[str]]
 
 
 # NOTE: redefining properties of TypedDict is not allowed

--- a/sources/rest_api/typing.py
+++ b/sources/rest_api/typing.py
@@ -16,7 +16,7 @@ from dlt.extract.incremental.typing import LastValueFunc
 
 from dlt.sources.helpers.rest_client.paginators import BasePaginator
 from dlt.sources.helpers.rest_client.typing import HTTPMethodBasic
-from dlt.sources.helpers.rest_client.auth import AuthConfigBase
+from dlt.sources.helpers.rest_client.auth import AuthConfigBase, TApiKeyLocation
 
 from dlt.common.schema.typing import (
     TColumnNames,
@@ -94,14 +94,51 @@ PaginatorConfig = Union[
 ]
 
 
-class SimpleTokenAuthConfig(TypedDict, total=False):
+AuthType = Literal["bearer", "api_key", "http_basic"]
+
+
+class AuthTypeConfig(TypedDict, total=True):
+    type: AuthType  # noqa
+
+
+class BearerTokenAuthConfig(AuthTypeConfig, total=True):
+    """Uses `token` for Bearer authentication in "Authorization" header."""
+
     token: str
+
+
+class ApiKeyAuthConfig(AuthTypeConfig, total=False):
+    """Uses provided `api_key` to create authorization data in the specified `location` (query, param, header, cookie) under specified `name`"""
+
+    name: Optional[str]
+    api_key: str
+    location: Optional[TApiKeyLocation]
+
+
+class HttpBasicAuthConfig(AuthTypeConfig, total=True):
+    """Uses HTTP basic authentication"""
+
+    username: str
+    password: str
+
+
+# TODO: add later
+# class OAuthJWTAuthConfig(AuthTypeConfig, total=True):
+
+
+AuthConfig = Union[
+    AuthConfigBase,
+    AuthType,
+    BearerTokenAuthConfig,
+    ApiKeyAuthConfig,
+    HttpBasicAuthConfig,
+]
 
 
 class ClientConfig(TypedDict, total=False):
     base_url: str
     headers: Optional[Dict[str, str]]
-    auth: Optional[Union[SimpleTokenAuthConfig, AuthConfigBase, Dict[str, str]]]
+    auth: Optional[AuthConfig]
     paginator: Optional[PaginatorConfig]
 
 

--- a/sources/rest_api_pipeline.py
+++ b/sources/rest_api_pipeline.py
@@ -13,6 +13,7 @@ def load_github() -> None:
         "client": {
             "base_url": "https://api.github.com/repos/dlt-hub/dlt/",
             "auth": {
+                "type": "bearer",
                 "token": dlt.secrets["github_token"],
             },
         },

--- a/sources/rest_api_pipeline.py
+++ b/sources/rest_api_pipeline.py
@@ -83,7 +83,7 @@ def load_pokemon() -> None:
             "client": {
                 "base_url": "https://pokeapi.co/api/v2/",
                 # If you leave out the paginator, it will be inferred from the API:
-                # paginator: "json_links",
+                # paginator: "json_response",
             },
             "resource_defaults": {
                 "endpoint": {

--- a/sources/unstructured_data/inbox/__init__.py
+++ b/sources/unstructured_data/inbox/__init__.py
@@ -216,7 +216,7 @@ def get_attachments_by_uid(
                             os.makedirs(os.path.dirname(attachment_path), exist_ok=True)
 
                             with open(attachment_path, "wb") as f:
-                                f.write(attachment_data)
+                                f.write(attachment_data)  # type: ignore[arg-type]
 
                             result = deepcopy(item)
                             result.update(email_info)

--- a/sources/unstructured_data/inbox/helpers.py
+++ b/sources/unstructured_data/inbox/helpers.py
@@ -58,8 +58,8 @@ def get_email_body(msg: Message) -> str:
         for part in msg.walk():
             content_type = part.get_content_type()
             if content_type == "text/plain":
-                body += part.get_payload(decode=True).decode(errors="ignore")
+                body += part.get_payload(decode=True).decode(errors="ignore")  # type: ignore[union-attr]
     else:
-        body = msg.get_payload(decode=True).decode(errors="ignore")
+        body = msg.get_payload(decode=True).decode(errors="ignore")  # type: ignore[union-attr]
 
     return body

--- a/tests/rest_api/source_configs.py
+++ b/tests/rest_api/source_configs.py
@@ -29,8 +29,8 @@ INVALID_CONFIGS = [
         },
     ),
     ConfigTest(
-        expected_message="Invalid paginator: invalid_paginator. Available options: json_links, header_links, auto, single_page",
-        exception=ValueError,
+        expected_message="field 'paginator' with value invalid_paginator is not one of:",
+        exception=DictValidationException,
         config={
             "client": {
                 "base_url": "https://api.example.com",
@@ -72,7 +72,7 @@ VALID_CONFIGS = [
                     "params": {
                         "limit": 100,
                     },
-                    "paginator": "json_links",
+                    "paginator": "json_response",
                 },
             },
         ],
@@ -95,7 +95,7 @@ VALID_CONFIGS = [
     {
         "client": {
             "base_url": "https://example.com",
-            "paginator": "header_links",
+            "paginator": "header_link",
             "auth": HttpBasicAuth("my-secret", ""),
         },
         "resources": ["users"],
@@ -115,7 +115,7 @@ VALID_CONFIGS = [
                             "initial_value": "2024-01-25T11:21:28Z",
                         },
                     },
-                    "paginator": "json_links",
+                    "paginator": "json_response",
                 },
             },
         ],
@@ -130,7 +130,7 @@ VALID_CONFIGS = [
                     "params": {
                         "limit": 100,
                     },
-                    "paginator": "json_links",
+                    "paginator": "json_response",
                     "incremental": {
                         "start_param": "since",
                         "end_param": "until",

--- a/tests/rest_api/source_configs.py
+++ b/tests/rest_api/source_configs.py
@@ -18,7 +18,7 @@ INVALID_CONFIGS = [
         config={"resources": []},
     ),
     ConfigTest(
-        expected_message="In ./client: following fields are unexpected {'invalid_key'}",
+        expected_message="In path ./client: following fields are unexpected {'invalid_key'}",
         exception=DictValidationException,
         config={
             "client": {

--- a/tests/rest_api/source_configs.py
+++ b/tests/rest_api/source_configs.py
@@ -1,7 +1,10 @@
 from collections import namedtuple
+from typing import List
 from dlt.common.exceptions import DictValidationException
 from dlt.sources.helpers.rest_client.paginators import SinglePagePaginator
 from dlt.sources.helpers.rest_client.auth import HttpBasicAuth
+
+from sources.rest_api.typing import PaginatorTypeConfig
 
 
 ConfigTest = namedtuple("ConfigTest", ["expected_message", "exception", "config"])
@@ -150,4 +153,35 @@ VALID_CONFIGS = [
         },
         "resources": ["users"],
     },
+    {
+        "client": {"base_url": "https://api.example.com"},
+        "resources": [
+            "posts",
+            {
+                "name": "post_comments",
+                "endpoint": {
+                    "path": "posts/{post_id}/comments",
+                    "params": {
+                        "post_id": {
+                            "type": "resolve",
+                            "resource": "posts",
+                            "field": "id",
+                        },
+                    },
+                },
+            },
+        ],
+    },
+]
+
+
+# NOTE: leaves some parameters as defaults to test them
+PAGINATOR_TYPE_CONFIGS: List[PaginatorTypeConfig] = [
+    {"type": "auto"},
+    {"type": "single_page"},
+    {"type": "page_number", "initial_page": 10, "total_path": "response.pages"},
+    {"type": "offset", "limit": 100, "maximum_offset": 1000},
+    {"type": "header_link", "links_next_key": "next_page"},
+    {"type": "json_response", "next_url_path": "response.nex_page_link"},
+    {"type": "cursor", "cursor_param": "cursor"},
 ]

--- a/tests/rest_api/test_configurations.py
+++ b/tests/rest_api/test_configurations.py
@@ -52,7 +52,7 @@ def test_valid_configurations(valid_config):
                                 "initial_value": "2024-01-25T11:21:28Z",
                             },
                         },
-                        "paginator": "json_links",
+                        "paginator": "json_response",
                     },
                 },
             ],
@@ -67,7 +67,7 @@ def test_valid_configurations(valid_config):
                         "params": {
                             "limit": 100,
                         },
-                        "paginator": "json_links",
+                        "paginator": "json_response",
                         "incremental": {
                             "start_param": "since",
                             "end_param": "until",

--- a/tests/rest_api/test_configurations.py
+++ b/tests/rest_api/test_configurations.py
@@ -1,7 +1,33 @@
 import pytest
-from copy import deepcopy
+from typing import get_args
+
+from dlt.common.utils import update_dict_nested, custom_environ
+from dlt.common.jsonpath import compile_path
+from dlt.common.configuration import inject_section
+from dlt.common.configuration.specs import ConfigSectionContext
+
 from sources.rest_api import rest_api_source
-from .source_configs import VALID_CONFIGS, INVALID_CONFIGS
+from sources.rest_api.config_setup import (
+    AUTH_MAP,
+    PAGINATOR_MAP,
+    create_auth,
+    create_paginator,
+)
+from sources.rest_api.typing import (
+    AuthType,
+    PaginatorType,
+    PaginatorTypeConfig,
+    RESTAPIConfig,
+)
+from dlt.sources.helpers.rest_client.paginators import (
+    HeaderLinkPaginator,
+    JSONResponsePaginator,
+    JSONResponseCursorPaginator,
+    OffsetPaginator,
+    PageNumberPaginator,
+)
+
+from .source_configs import PAGINATOR_TYPE_CONFIGS, VALID_CONFIGS, INVALID_CONFIGS
 
 
 @pytest.mark.parametrize("expected_message, exception, invalid_config", INVALID_CONFIGS)
@@ -15,72 +41,82 @@ def test_valid_configurations(valid_config):
     rest_api_source(valid_config)
 
 
-@pytest.mark.parametrize(
-    "config",
-    [
-        {
-            "client": {"base_url": "https://api.example.com"},
-            "resources": [
-                "posts",
-                {
-                    "name": "post_comments",
-                    "endpoint": {
-                        "path": "posts/{post_id}/comments",
-                        "params": {
-                            "post_id": {
-                                "type": "resolve",
-                                "resource": "posts",
-                                "field": "id",
-                            },
-                        },
-                    },
-                },
-            ],
-        },
-        {
-            "client": {"base_url": "https://api.example.com"},
-            "resources": [
-                {
-                    "name": "posts",
-                    "endpoint": {
-                        "path": "posts",
-                        "params": {
-                            "limit": 100,
-                            "since": {
-                                "type": "incremental",
-                                "cursor_path": "updated_at",
-                                "initial_value": "2024-01-25T11:21:28Z",
-                            },
-                        },
-                        "paginator": "json_response",
-                    },
-                },
-            ],
-        },
-        {
-            "client": {"base_url": "https://api.example.com"},
-            "resources": [
-                {
-                    "name": "posts",
-                    "endpoint": {
-                        "path": "posts",
-                        "params": {
-                            "limit": 100,
-                        },
-                        "paginator": "json_response",
-                        "incremental": {
-                            "start_param": "since",
-                            "end_param": "until",
-                            "cursor_path": "updated_at",
-                            "initial_value": "2024-01-25T11:21:28Z",
-                        },
-                    },
-                },
-            ],
-        },
-    ],
-)
+@pytest.mark.parametrize("config", VALID_CONFIGS)
 def test_configurations_dict_is_not_modified_in_place(config):
-    config_copy = deepcopy(config)
+    # deep clone dicts but do not touch instances of classes so ids still compare
+    config_copy = update_dict_nested({}, config)
     rest_api_source(config)
     assert config_copy == config
+
+
+@pytest.mark.parametrize("paginator_type", get_args(PaginatorType))
+def test_paginator_shorthands(paginator_type: PaginatorType) -> None:
+    # config: RESTAPIConfig = {
+    #     "client": {
+    #         "base_url": "https://api.example.com",
+    #         "paginator": paginator_type
+    #     },
+    #     "resources": [
+    #         "resource"
+    #     ]
+    # }
+    try:
+        create_paginator(paginator_type)
+    except ValueError as v_ex:
+        # offset paginator cannot be instantiated
+        assert paginator_type == "offset"
+        assert "offset" in str(v_ex)
+
+
+@pytest.mark.parametrize("paginator_type_config", PAGINATOR_TYPE_CONFIGS)
+def test_paginator_type_configs(paginator_type_config: PaginatorTypeConfig) -> None:
+    paginator = create_paginator(paginator_type_config)
+    if paginator_type_config["type"] == "auto":
+        assert paginator is None
+    else:
+        # assert types and default params
+        assert isinstance(paginator, PAGINATOR_MAP[paginator_type_config["type"]])
+        # check if params are bound
+        if isinstance(paginator, HeaderLinkPaginator):
+            assert paginator.links_next_key == "next_page"
+        if isinstance(paginator, PageNumberPaginator):
+            assert paginator.current_value == 10
+            assert paginator.param_name == "page"
+            assert paginator.total_path == compile_path("response.pages")
+            assert paginator.maximum_value is None
+        if isinstance(paginator, OffsetPaginator):
+            assert paginator.current_value == 0
+            assert paginator.param_name == "offset"
+            assert paginator.limit == 100
+            assert paginator.limit_param == "limit"
+            assert paginator.total_path == compile_path("total")
+            assert paginator.maximum_value == 1000
+        if isinstance(paginator, JSONResponsePaginator):
+            assert paginator.next_url_path == compile_path("response.nex_page_link")
+        if isinstance(paginator, JSONResponseCursorPaginator):
+            assert paginator.cursor_path == compile_path("cursors.next")
+            assert paginator.cursor_param == "cursor"
+
+
+def test_paginator_instance_config() -> None:
+    paginator = OffsetPaginator(limit=100)
+    assert create_paginator(paginator) is paginator
+
+
+@pytest.mark.parametrize("auth_type", get_args(AuthType))
+def test_auth_shorthands(auth_type: AuthType) -> None:
+    # mock all envs
+    with custom_environ(
+        {
+            "SOURCES__REST_API__CREDENTIALS__TOKEN": "token",
+            "SOURCES__REST_API__CREDENTIALS__API_KEY": "api_key",
+            "SOURCES__REST_API__CREDENTIALS__USERNAME": "username",
+            "SOURCES__REST_API__CREDENTIALS__PASSWORD": "password",
+        }
+    ):
+        # shorthands need to instantiate from config
+        with inject_section(
+            ConfigSectionContext(sections=("sources", "rest_api")), merge_existing=False
+        ):
+            auth = create_auth(auth_type)
+            assert isinstance(auth, AUTH_MAP[auth_type])

--- a/tests/rest_api/test_configurations.py
+++ b/tests/rest_api/test_configurations.py
@@ -1,20 +1,29 @@
 import pytest
+from copy import copy
 from typing import get_args
 
+import dlt
 from dlt.common.utils import update_dict_nested, custom_environ
 from dlt.common.jsonpath import compile_path
 from dlt.common.configuration import inject_section
 from dlt.common.configuration.specs import ConfigSectionContext
+from dlt.sources.helpers.rest_client.paginators import (
+    SinglePagePaginator,
+    HeaderLinkPaginator,
+)
 
-from sources.rest_api import rest_api_source
+from sources.rest_api import rest_api_source, rest_api_resources
 from sources.rest_api.config_setup import (
     AUTH_MAP,
     PAGINATOR_MAP,
+    _setup_single_entity_endpoint,
     create_auth,
     create_paginator,
+    _make_endpoint_resource,
 )
 from sources.rest_api.typing import (
     AuthType,
+    AuthTypeConfig,
     PaginatorType,
     PaginatorTypeConfig,
     RESTAPIConfig,
@@ -26,8 +35,20 @@ from dlt.sources.helpers.rest_client.paginators import (
     OffsetPaginator,
     PageNumberPaginator,
 )
+from dlt.sources.helpers.rest_client.auth import (
+    AuthConfigBase,
+    HttpBasicAuth,
+    BearerTokenAuth,
+    APIKeyAuth,
+    OAuthJWTAuth,
+)
 
-from .source_configs import PAGINATOR_TYPE_CONFIGS, VALID_CONFIGS, INVALID_CONFIGS
+from .source_configs import (
+    AUTH_TYPE_CONFIGS,
+    PAGINATOR_TYPE_CONFIGS,
+    VALID_CONFIGS,
+    INVALID_CONFIGS,
+)
 
 
 @pytest.mark.parametrize("expected_message, exception, invalid_config", INVALID_CONFIGS)
@@ -51,15 +72,6 @@ def test_configurations_dict_is_not_modified_in_place(config):
 
 @pytest.mark.parametrize("paginator_type", get_args(PaginatorType))
 def test_paginator_shorthands(paginator_type: PaginatorType) -> None:
-    # config: RESTAPIConfig = {
-    #     "client": {
-    #         "base_url": "https://api.example.com",
-    #         "paginator": paginator_type
-    #     },
-    #     "resources": [
-    #         "resource"
-    #     ]
-    # }
     try:
         create_paginator(paginator_type)
     except ValueError as v_ex:
@@ -104,14 +116,17 @@ def test_paginator_instance_config() -> None:
 
 
 @pytest.mark.parametrize("auth_type", get_args(AuthType))
-def test_auth_shorthands(auth_type: AuthType) -> None:
-    # mock all envs
+@pytest.mark.parametrize(
+    "section", ("SOURCES__REST_API__CREDENTIALS", "SOURCES__CREDENTIALS", "CREDENTIALS")
+)
+def test_auth_shorthands(auth_type: AuthType, section: str) -> None:
+    # mock all required envs
     with custom_environ(
         {
-            "SOURCES__REST_API__CREDENTIALS__TOKEN": "token",
-            "SOURCES__REST_API__CREDENTIALS__API_KEY": "api_key",
-            "SOURCES__REST_API__CREDENTIALS__USERNAME": "username",
-            "SOURCES__REST_API__CREDENTIALS__PASSWORD": "password",
+            f"{section}__TOKEN": "token",
+            f"{section}__API_KEY": "api_key",
+            f"{section}__USERNAME": "username",
+            f"{section}__PASSWORD": "password",
         }
     ):
         # shorthands need to instantiate from config
@@ -120,3 +135,273 @@ def test_auth_shorthands(auth_type: AuthType) -> None:
         ):
             auth = create_auth(auth_type)
             assert isinstance(auth, AUTH_MAP[auth_type])
+            if isinstance(auth, BearerTokenAuth):
+                assert auth.token == "token"
+            if isinstance(auth, APIKeyAuth):
+                assert auth.api_key == "api_key"
+                assert auth.location == "header"
+                assert auth.name == "Authorization"
+            if isinstance(auth, HttpBasicAuth):
+                assert auth.username == "username"
+                assert auth.password == "password"
+
+
+@pytest.mark.parametrize("auth_type_config", AUTH_TYPE_CONFIGS)
+@pytest.mark.parametrize(
+    "section", ("SOURCES__REST_API__CREDENTIALS", "SOURCES__CREDENTIALS", "CREDENTIALS")
+)
+def test_auth_type_configs(auth_type_config: AuthTypeConfig, section: str) -> None:
+    # mock all required envs
+    with custom_environ(
+        {
+            f"{section}__API_KEY": "api_key",
+            f"{section}__NAME": "session-cookie",
+            f"{section}__PASSWORD": "password",
+        }
+    ):
+        # shorthands need to instantiate from config
+        with inject_section(
+            ConfigSectionContext(sections=("sources", "rest_api")), merge_existing=False
+        ):
+            auth = create_auth(auth_type_config)
+            assert isinstance(auth, AUTH_MAP[auth_type_config["type"]])
+            if isinstance(auth, BearerTokenAuth):
+                # from typed dict
+                assert auth.token == "token"
+            if isinstance(auth, APIKeyAuth):
+                assert auth.location == "cookie"
+                # injected
+                assert auth.api_key == "api_key"
+                assert auth.name == "session-cookie"
+            if isinstance(auth, HttpBasicAuth):
+                # typed dict
+                assert auth.username == "username"
+                # injected
+                assert auth.password == "password"
+
+
+@pytest.mark.parametrize(
+    "section", ("SOURCES__REST_API__CREDENTIALS", "SOURCES__CREDENTIALS", "CREDENTIALS")
+)
+def test_auth_instance_config(section: str) -> None:
+    auth = APIKeyAuth(location="param", name="token")
+    with custom_environ(
+        {
+            f"{section}__API_KEY": "api_key",
+            f"{section}__NAME": "session-cookie",
+        }
+    ):
+        # shorthands need to instantiate from config
+        with inject_section(
+            ConfigSectionContext(sections=("sources", "rest_api")), merge_existing=False
+        ):
+            # this also resolved configuration
+            resolved_auth = create_auth(auth)
+            assert resolved_auth is auth
+            # explicit
+            assert auth.location == "param"
+            # injected
+            assert auth.api_key == "api_key"
+            # config overrides explicit (TODO: reverse)
+            assert auth.name == "session-cookie"
+
+
+def test_resource_expand() -> None:
+    # convert str into name / path
+    assert _make_endpoint_resource("path", {}) == {
+        "name": "path",
+        "endpoint": {"path": "path"},
+    }
+    # expand endpoint str into path
+    assert _make_endpoint_resource({"name": "resource", "endpoint": "path"}, {}) == {
+        "name": "resource",
+        "endpoint": {"path": "path"},
+    }
+    # expand name into path with optional endpoint
+    assert _make_endpoint_resource({"name": "resource"}, {}) == {
+        "name": "resource",
+        "endpoint": {"path": "resource"},
+    }
+    # endpoint path is optional
+    assert _make_endpoint_resource({"name": "resource", "endpoint": {}}, {}) == {
+        "name": "resource",
+        "endpoint": {"path": "resource"},
+    }
+
+
+def test_resource_endpoint_deep_merge() -> None:
+    # columns deep merged
+    resource = _make_endpoint_resource(
+        {
+            "name": "resources",
+            "columns": [
+                {"name": "col_a", "data_type": "bigint"},
+                {"name": "col_b"},
+            ],
+        },
+        {
+            "columns": [
+                {"name": "col_a", "data_type": "text", "primary_key": True},
+                {"name": "col_c", "data_type": "timestamp", "partition": True},
+            ]
+        },
+    )
+    assert resource["columns"] == {
+        # data_type and primary_key merged
+        "col_a": {"name": "col_a", "data_type": "bigint", "primary_key": True},
+        # from defaults
+        "col_c": {"name": "col_c", "data_type": "timestamp", "partition": True},
+        # from resource (partial column moved to the end)
+        "col_b": {"name": "col_b"},
+    }
+    # json and params deep merged
+    resource = _make_endpoint_resource(
+        {
+            "name": "resources",
+            "endpoint": {
+                "json": {"param1": "A", "param2": "B"},
+                "params": {"param1": "A", "param2": "B"},
+            },
+        },
+        {
+            "endpoint": {
+                "json": {"param1": "X", "param3": "Y"},
+                "params": {"param1": "X", "param3": "Y"},
+            }
+        },
+    )
+    assert resource["endpoint"] == {
+        "json": {"param1": "A", "param3": "Y", "param2": "B"},
+        "params": {"param1": "A", "param3": "Y", "param2": "B"},
+        "path": "resources",
+    }
+
+
+def test_resource_endpoint_shallow_merge() -> None:
+    # merge paginators and other typed dicts as whole
+    resource_config = {
+        "name": "resources",
+        "max_table_nesting": 5,
+        "write_disposition": {"disposition": "merge", "x-merge-strategy": "scd2"},
+        "schema_contract": {"tables": "freeze"},
+        "endpoint": {
+            "paginator": {"type": "cursor", "cursor_param": "cursor"},
+            "incremental": {"cursor_path": "$", "start_param": "since"},
+        },
+    }
+
+    resource = _make_endpoint_resource(
+        resource_config,
+        {
+            "max_table_nesting": 1,
+            "parallel": True,
+            "write_disposition": {
+                "disposition": "replace",
+            },
+            "schema_contract": {"columns": "freeze"},
+            "endpoint": {
+                "paginator": {
+                    "type": "header_link",
+                },
+                "incremental": {
+                    "cursor_path": "response.id",
+                    "start_param": "since",
+                    "end_param": "before",
+                },
+            },
+        },
+    )
+    # resource should keep all values, just parallel is added
+    expected_resource = copy(resource_config)
+    expected_resource["parallel"] = True
+    assert resource == expected_resource
+
+
+def test_resource_merge_with_objects() -> None:
+    paginator = SinglePagePaginator()
+    incremental = dlt.sources.incremental[int]("id", row_order="asc")
+    resource = _make_endpoint_resource(
+        {
+            "name": "resource",
+            "endpoint": {
+                "path": "path/to",
+                "paginator": paginator,
+                "params": {"since": incremental},
+            },
+        },
+        {
+            "table_name": lambda item: item["type"],
+            "endpoint": {
+                "paginator": HeaderLinkPaginator(),
+                "params": {
+                    "since": dlt.sources.incremental[int]("id", row_order="desc")
+                },
+            },
+        },
+    )
+    # objects are as is, not cloned
+    assert resource["endpoint"]["paginator"] is paginator
+    assert resource["endpoint"]["params"]["since"] is incremental
+    # callable coming from default
+    assert callable(resource["table_name"])
+
+
+def test_resource_merge_with_none() -> None:
+    endpoint_config = {
+        "name": "resource",
+        "endpoint": {"path": "user/{id}", "paginator": None, "data_selector": None},
+    }
+    # None should be able to reset the default
+    resource = _make_endpoint_resource(
+        endpoint_config,
+        {"endpoint": {"paginator": SinglePagePaginator(), "data_selector": "data"}},
+    )
+    # nones will overwrite defaults
+    assert resource == endpoint_config
+
+
+def test_setup_for_single_item_endpoint() -> None:
+    # single item should revert to single page validator
+    endpoint = _setup_single_entity_endpoint({"path": "user/{id}"})
+    assert endpoint["data_selector"] == "$"
+    assert isinstance(endpoint["paginator"], SinglePagePaginator)
+
+    # this is not single page
+    endpoint = _setup_single_entity_endpoint({"path": "user/{id}/messages"})
+    assert "data_selector" not in endpoint
+
+    # simulate using None to remove defaults
+    endpoint_config = {
+        "name": "resource",
+        "endpoint": {"path": "user/{id}", "paginator": None, "data_selector": None},
+    }
+    # None should be able to reset the default
+    resource = _make_endpoint_resource(
+        endpoint_config,
+        {"endpoint": {"paginator": HeaderLinkPaginator(), "data_selector": "data"}},
+    )
+    endpoint = _setup_single_entity_endpoint(resource["endpoint"])
+    assert endpoint["data_selector"] == "$"
+    assert isinstance(endpoint["paginator"], SinglePagePaginator)
+
+
+def test_resource_schema() -> None:
+    config: RESTAPIConfig = {
+        "client": {
+            "base_url": "https://api.example.com",
+        },
+        "resources": [
+            {
+                "name": "resource",
+                "endpoint": {
+                    "path": "user/{id}",
+                    "paginator": None,
+                    "data_selector": None,
+                },
+            }
+        ],
+    }
+    resources = rest_api_resources(config)
+    assert len(resources) == 1
+    resource = resources[0]
+    assert resource.name == "resource"

--- a/tests/rest_api/test_configurations.py
+++ b/tests/rest_api/test_configurations.py
@@ -206,6 +206,12 @@ def test_auth_instance_config(section: str) -> None:
             assert auth.name == "session-cookie"
 
 
+def test_bearer_token_fallback() -> None:
+    auth = create_auth({"token": "secret"})
+    assert isinstance(auth, BearerTokenAuth)
+    assert auth.token == "secret"
+
+
 def test_resource_expand() -> None:
     # convert str into name / path
     assert _make_endpoint_resource("path", {}) == {

--- a/tests/rest_api/test_rest_api_source_offline.py
+++ b/tests/rest_api/test_rest_api_source_offline.py
@@ -200,7 +200,7 @@ def test_posts_under_results_key(mock_api_server):
                     "endpoint": {
                         "path": "posts_under_a_different_key",
                         "data_selector": "many-results",
-                        "paginator": "json_links",
+                        "paginator": "json_response",
                     },
                 },
             ],
@@ -223,7 +223,7 @@ def test_posts_without_key(mock_api_server):
         {
             "client": {
                 "base_url": "https://api.example.com",
-                "paginator": "header_links",
+                "paginator": "header_link",
             },
             "resources": [
                 {

--- a/tests/rest_api/test_rest_api_source_offline.py
+++ b/tests/rest_api/test_rest_api_source_offline.py
@@ -2,7 +2,7 @@ import pytest
 
 import dlt
 from dlt.pipeline.exceptions import PipelineStepFailed
-from dlt.sources.helpers.rest_client.paginators import BasePaginator
+from dlt.sources.helpers.rest_client.paginators import BaseReferencePaginator
 
 from tests.utils import assert_load_info, load_table_counts, assert_query_data
 
@@ -135,15 +135,15 @@ def test_ignoring_endpoint_returning_404(mock_api_server):
 
 
 def test_source_with_post_request(mock_api_server):
-    class JSONBodyPageCursorPaginator(BasePaginator):
+    class JSONBodyPageCursorPaginator(BaseReferencePaginator):
         def update_state(self, response):
-            self.next_reference = response.json().get("next_page")
+            self._next_reference = response.json().get("next_page")
 
         def update_request(self, request):
             if request.json is None:
                 request.json = {}
 
-            request.json["page"] = self.next_reference
+            request.json["page"] = self._next_reference
 
     mock_source = rest_api_source(
         {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Tell us what you do here
<!--
Pick the relevant item or items and remove the rest: 
-->
- improving, documenting, or customizing an existing source (please link an issue or describe below)

### Short description
1. updates `ResourceBase` to accept all the current resource decorator hints
2. updates mypy to one used by dlt
3. fixes a few rest api tests
4. types paginator configs to match signatures in REST Client
5. merges ResourceEndpoint keeping TypedDict as a whole
6. renames paginator shorthands to match REST Client
```
header_links -> header_link
json_links -> json_response
```
7. adds typed dicts for `incremental` and `resolve` params
8. changes how single entity endpoints are handled
9. adds tests for the above
<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues
fixes: #445 
fixes: #455 
