### PR TITLE
sql_database: Add flag to include views with reflected tables

### DIFF
--- a/sources/sql_database/__init__.py
+++ b/sources/sql_database/__init__.py
@@ -34,6 +34,7 @@ def sql_database(
     defer_table_reflect: Optional[bool] = dlt.config.value,
     table_adapter_callback: Callable[[Table], None] = None,
     backend_kwargs: Dict[str, Any] = None,
+    include_views: bool = False,
 ) -> Iterable[DltResource]:
     """
     A dlt source which loads data from an SQL database using SQLAlchemy.
@@ -55,6 +56,7 @@ def sql_database(
             Enable this option when running on Airflow. Available on dlt 0.4.4 and later.
         table_adapter_callback: (Callable): Receives each reflected table. May be used to modify the list of columns that will be selected.
         backend_kwargs (**kwargs): kwargs passed to table backend ie. "conn" is used to pass specialized connection string to connectorx.
+        include_views (bool): Reflect views as well as tables. Note view names included in `table_names` are always included regardless of this setting.
     Returns:
         Iterable[DltResource]: A list of DLT resources for each table to be loaded.
     """
@@ -73,7 +75,7 @@ def sql_database(
     else:
         if defer_table_reflect:
             raise ValueError("You must pass table names to defer table reflection")
-        metadata.reflect(bind=engine)
+        metadata.reflect(bind=engine, views=include_views)
         tables = list(metadata.tables.values())
 
     for table in tables:
@@ -120,7 +122,7 @@ def sql_table(
 
     Args:
         credentials (Union[ConnectionStringCredentials, Engine, str]): Database credentials or an `Engine` instance representing the database connection.
-        table (str): Name of the table to load.
+        table (str): Name of the table or view to load.
         schema (Optional[str]): Optional name of the schema the table belongs to.
         metadata (Optional[MetaData]): Optional `sqlalchemy.MetaData` instance. If provided, the `schema` argument is ignored.
         incremental (Optional[dlt.sources.incremental[Any]]): Option to enable incremental loading for the table.

--- a/tests/sql_database/sql_source.py
+++ b/tests/sql_database/sql_source.py
@@ -265,7 +265,9 @@ class SQLAlchemySourceDB:
         # View is the same number of rows as the table
         view_info = deepcopy(info)
         view_info["is_view"] = True
-        self.table_infos.setdefault("chat_message_view", view_info)
+        view_info = self.table_infos.setdefault("chat_message_view", view_info)
+        view_info["row_count"] = info["row_count"]
+        view_info["ids"] = info["ids"]
         return message_ids
 
     def _fake_precision_data(

--- a/tests/sql_database/sql_source.py
+++ b/tests/sql_database/sql_source.py
@@ -1,5 +1,6 @@
 from typing import List, TypedDict, Dict
 import random
+from copy import deepcopy
 
 import mimesis
 from sqlalchemy import (
@@ -162,12 +163,31 @@ class SQLAlchemySourceDB:
 
         self.metadata.create_all(bind=self.engine)
 
+        # Create a view
+        q = f"""
+        CREATE VIEW {self.schema}.chat_message_view AS
+        SELECT
+            cm.id,
+            cm.content,
+            cm.created_at,
+            cm.updated_at,
+            au.email as user_email,
+            au.display_name as user_display_name,
+            cc.name as channel_name
+        FROM {self.schema}.chat_message cm
+        JOIN {self.schema}.app_user au ON cm.user_id = au.id
+        JOIN {self.schema}.chat_channel cc ON cm.channel_id = cc.id
+        """
+        with self.engine.begin() as conn:
+            conn.execute(text(q))
+
     def _fake_users(self, n: int = 8594) -> List[int]:
         person = mimesis.Person()
         user_ids: List[int] = []
         table = self.metadata.tables[f"{self.schema}.app_user"]
         info = self.table_infos.setdefault(
-            "app_user", dict(row_count=0, ids=[], created_at=IncrementingDate())
+            "app_user",
+            dict(row_count=0, ids=[], created_at=IncrementingDate(), is_view=False),
         )
         dt = info["created_at"]
         for chunk in chunks(range(n), 5000):
@@ -193,7 +213,8 @@ class SQLAlchemySourceDB:
         table = self.metadata.tables[f"{self.schema}.chat_channel"]
         channel_ids: List[int] = []
         info = self.table_infos.setdefault(
-            "chat_channel", dict(row_count=0, ids=[], created_at=IncrementingDate())
+            "chat_channel",
+            dict(row_count=0, ids=[], created_at=IncrementingDate(), is_view=False),
         )
         dt = info["created_at"]
         for chunk in chunks(range(n), 5000):
@@ -221,7 +242,8 @@ class SQLAlchemySourceDB:
         table = self.metadata.tables[f"{self.schema}.chat_message"]
         message_ids: List[int] = []
         info = self.table_infos.setdefault(
-            "chat_message", dict(row_count=0, ids=[], created_at=IncrementingDate())
+            "chat_message",
+            dict(row_count=0, ids=[], created_at=IncrementingDate(), is_view=False),
         )
         dt = info["created_at"]
         for chunk in chunks(range(n), 5000):
@@ -240,13 +262,19 @@ class SQLAlchemySourceDB:
                 message_ids.extend(result.scalars())
         info["row_count"] += len(message_ids)
         info["ids"].extend(message_ids)
+        # View is the same number of rows as the table
+        view_info = deepcopy(info)
+        view_info["is_view"] = True
+        self.table_infos.setdefault("chat_message_view", view_info)
         return message_ids
 
     def _fake_precision_data(
         self, table_name: str, n: int = 100, null_n: int = 0
     ) -> None:
         table = self.metadata.tables[f"{self.schema}.{table_name}"]
-        self.table_infos.setdefault(table_name, dict(row_count=n + null_n))
+        self.table_infos.setdefault(
+            table_name, dict(row_count=n + null_n, is_view=False)
+        )
         rows = [
             dict(
                 int_col=random.randrange(-2147483648, 2147483647),
@@ -302,3 +330,4 @@ class TableInfo(TypedDict):
     row_count: int
     ids: List[int]
     created_at: IncrementingDate
+    is_view: bool


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Tell us what you do here

- Add flag `include_views` to `sql_database` source to enable reflecting views
- Test for the flag
- Test for `sql_table` works when the table name is a view
- Test for `sql_database` always includes views when they're passed in `table_names` regardless of the `include_views` flag

### Related Issues
- Resolves #459 
