### PR TITLE
reset_api: allow JSONPath in field value in ResolveParamConfig

### DIFF
--- a/sources/rest_api/typing.py
+++ b/sources/rest_api/typing.py
@@ -3,11 +3,11 @@ from typing import (
     Dict,
     List,
     Literal,
-    NamedTuple,
     Optional,
     TypedDict,
     Union,
 )
+from dataclasses import dataclass, field
 
 from dlt.common import jsonpath
 from dlt.common.typing import TSortOrder
@@ -202,9 +202,14 @@ class IncrementalParamConfig(ParamBindConfig, IncrementalArgs):
     # param_type: Optional[Literal["start_param", "end_param"]]
 
 
-class ResolvedParam(NamedTuple):
+@dataclass
+class ResolvedParam:
     param_name: str
     resolve_config: ResolveParamConfig
+    field_path: jsonpath.TJsonPath = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.field_path = jsonpath.compile_path(self.resolve_config["field"])
 
 
 class ResponseAction(TypedDict, total=False):

--- a/tests/rest_api/test_configurations.py
+++ b/tests/rest_api/test_configurations.py
@@ -472,6 +472,16 @@ def test_process_parent_data_item():
     )
     assert parent_record == {"_issues_obj_id": 12345, "_issues_obj_node": "node_1"}
 
+    # test nested data
+    resolve_param_nested = ResolvedParam(
+        "id", {"field": "some_results.obj_id", "resource": "issues", "type": "resolve"}
+    )
+    item = {"some_results": {"obj_id": 12345}}
+    bound_path, parent_record = process_parent_data_item(
+        "dlt-hub/dlt/issues/{id}/comments", item, resolve_param_nested, None
+    )
+    assert bound_path == "dlt-hub/dlt/issues/12345/comments"
+
     # param path not found
     with pytest.raises(ValueError) as val_ex:
         bound_path, parent_record = process_parent_data_item(


### PR DESCRIPTION
This pull request adds ability to use JSONPath in [path parameter resolve configuration](https://dlthub.com/docs/dlt-ecosystem/verified-sources/rest_api#define-resource-relationships):

Example:

Suppose you have parent resource data item like:

```
{
    "number": 42,
    "nested_data": {
       "some_nested_identifier": 24,
       ...
    }
}
```

Before this PR you could only refer the `number` field, like so: 

```
{
    "resources": [
        ...
        {
            "name": "issue_comments",
            "endpoint": {
                "path": "issues/{issue_number}/comments",
                "params": {
                    "issue_number": {
                        "type": "resolve",
                        "resource": "issues",
                        "field": "number",
                    }
                },
            },
        },
    ],
}
```

With this PR you can also refer `nested_data.some_nested_identifier` field by using JSONPath:

```
{
    "resources": [
        ...
        {
            "name": "issue_comments",
            "endpoint": {
                "path": "issues/{issue_number}/comments",
                "params": {
                    "issue_number": {
                        "type": "resolve",
                        "resource": "issues",
                        "field": "nested_data.some_nested_identifier",
                    }
                },
            },
        },
    ],
}
```
