### PR TITLE
RESTAPI: Handle resolve params which return a list of elements 

### DIFF
--- a/sources/rest_api/__init__.py
+++ b/sources/rest_api/__init__.py
@@ -308,22 +308,23 @@ def create_resources(
                         params[incremental_param.end] = incremental_object.end_value
 
                 for item in items:
-                    formatted_path, parent_record = process_parent_data_item(
+                    formatted_paths, parent_record = process_parent_data_item(
                         path, item, resolved_param, include_from_parent
                     )
 
-                    for child_page in client.paginate(
-                        method=method,
-                        path=formatted_path,
-                        params=params,
-                        paginator=paginator,
-                        data_selector=data_selector,
-                        hooks=hooks,
-                    ):
-                        if parent_record:
-                            for child_record in child_page:
-                                child_record.update(parent_record)
-                        yield child_page
+                    for formatted_path in formatted_paths:
+                        for child_page in client.paginate(
+                            method=method,
+                            path=formatted_path,
+                            params=params,
+                            paginator=paginator,
+                            data_selector=data_selector,
+                            hooks=hooks,
+                        ):
+                            if parent_record:
+                                for child_record in child_page:
+                                    child_record.update(parent_record)
+                            yield child_page
 
             resources[resource_name] = dlt.resource(  # type: ignore[call-overload]
                 paginate_dependent_resource,

--- a/sources/rest_api/config_setup.py
+++ b/sources/rest_api/config_setup.py
@@ -13,6 +13,7 @@ from typing import (
 )
 import graphlib  # type: ignore[import,unused-ignore]
 import string
+import json
 
 import dlt
 from dlt.common import logger
@@ -423,11 +424,11 @@ def process_parent_data_item(
     ) -> List[str]:
         try:
             # Attempt to parse the string as a Python literal
-            parsed = ast.literal_eval(s)
+            parsed = json.loads(s)
             # Check if the parsed object is a list
             if isinstance(parsed, list):
                 return parsed
-        except (ValueError, SyntaxError):
+        except (ValueError, json.JSONDecodeError):
             pass
         # If parsing fails or the parsed object is not a list, return the string in a list
         return [s]

--- a/sources/rest_api/config_setup.py
+++ b/sources/rest_api/config_setup.py
@@ -442,7 +442,7 @@ def process_parent_data_item(
         raise ValueError(
             f"Transformer expects a field '{field_path}' to be present in the incoming data from resource {parent_resource_name} in order to bind it to path param {resolved_param.param_name}. Available parent fields are {', '.join(item.keys())}"
         )
-    
+
     bound_path = [path.format(**{resolved_param.param_name: field_value}) for field_value in to_list(field_values[0])]
 
     # bound_path = path.format(**{resolved_param.param_name: field_values[0]})

--- a/sources/rest_api/config_setup.py
+++ b/sources/rest_api/config_setup.py
@@ -415,10 +415,12 @@ def process_parent_data_item(
     item: Dict[str, Any],
     resolved_param: ResolvedParam,
     include_from_parent: List[str],
-) -> Tuple[str, Dict[str, Any]]:
+) -> Tuple[List[str], Dict[str, Any]]:
 
 
-    def to_list(s):
+    def to_list(
+        s: str,
+    ) -> List[str]:
         try:
             # Attempt to parse the string as a Python literal
             parsed = ast.literal_eval(s)

--- a/sources/rest_api/config_setup.py
+++ b/sources/rest_api/config_setup.py
@@ -13,7 +13,6 @@ from typing import (
 )
 import graphlib  # type: ignore[import,unused-ignore]
 import string
-import json
 
 import dlt
 from dlt.common import logger
@@ -418,19 +417,11 @@ def process_parent_data_item(
     include_from_parent: List[str],
 ) -> Tuple[List[str], Dict[str, Any]]:
 
-
     def to_list(
-        s: str,
-    ) -> List[str]:
-        try:
-            # Attempt to parse the string as a Python literal
-            parsed = json.loads(s)
-            # Check if the parsed object is a list
-            if isinstance(parsed, list):
-                return parsed
-        except (ValueError, json.JSONDecodeError):
-            pass
-        # If parsing fails or the parsed object is not a list, return the string in a list
+            s: Any,
+        ) -> List[Any]:
+        if isinstance(s, list):
+            return s
         return [s]
 
     parent_resource_name = resolved_param.resolve_config["resource"]


### PR DESCRIPTION
### Tell us what you do here
I modified the method that builds the path for resolve params

### Short description

I introduced an internal method (`to_list()`) to convert the value returned by the parent resource to a Python list:
- in case the parent resource returns a valid N-elements list, it is split into a N-element list
- in case the parent resource returns a single value (or better something which is not a list), the value is put in a list with a single element.

Then `process_parent_data_item()` is returning not a single path but a list of paths, then `paginate_dependent_resource` needs to yield values from all the paths in the list.

### Additional Context

This is a fairy common use case for APIs returning multiple elements from a search endpoint
