### PR TITLE
feat(github): add stargazers

### DIFF
--- a/sources/github/__init__.py
+++ b/sources/github/__init__.py
@@ -7,7 +7,7 @@ import dlt
 from dlt.common.typing import TDataItems
 from dlt.sources import DltResource
 
-from .helpers import get_reactions_data, get_rest_pages
+from .helpers import get_reactions_data, get_rest_pages, get_stargazers
 
 
 @dlt.source
@@ -108,3 +108,42 @@ def github_repo_events(
                 break
 
     return repo_events
+
+
+@dlt.source
+def github_stargazers(
+    owner: str,
+    name: str,
+    access_token: str = dlt.secrets.value,
+    items_per_page: int = 100,
+    max_items: Optional[int] = None,
+) -> Sequence[DltResource]:
+    """Get stargazers in the repo `name` with owner `owner`.
+
+    This source uses graphql to retrieve all staragars with the associated starred date,
+    Internally graphql is used to retrieve data. It is cost optimized and you are able to retrieve the
+    data for fairly large repos quickly and cheaply.
+
+    Args:
+        owner (str): The repository owner
+        name (str): The repository name
+        access_token (str): The classic access token. Will be injected from secrets if not provided.
+        items_per_page (int, optional): How many issues/pull requests to get in single page. Defaults to 100.
+        max_items (int, optional): How many issues/pull requests to get in total. None means All.
+
+    Returns:
+        Sequence[DltResource]: Two DltResources: `issues` with issues and `pull_requests` with pull requests
+    """
+    return (
+        dlt.resource(
+            get_stargazers(
+                owner,
+                name,
+                access_token,
+                items_per_page,
+                max_items,
+            ),
+            name="stargazers",
+            write_disposition="replace",
+        ),
+    )

--- a/sources/github/queries.py
+++ b/sources/github/queries.py
@@ -86,3 +86,30 @@ node_%s: node(id:"%s") {
     }
   }
 """
+
+STARGAZERS_QUERY = """
+query($owner: String!, $name: String!, $items_per_page: Int!, $page_after: String) {
+  repository(owner: $owner, name: $name) {
+    stargazers(first: $items_per_page, orderBy: {field: STARRED_AT, direction: DESC}, after: $page_after) {
+      pageInfo {
+        endCursor
+        startCursor
+      }
+      edges {
+        starredAt
+        node {
+          login
+          avatarUrl
+          url
+        }
+      }
+    }
+  }
+  rateLimit {
+    limit
+    cost
+    remaining
+    resetAt
+  }
+}
+"""

--- a/sources/github_pipeline.py
+++ b/sources/github_pipeline.py
@@ -1,6 +1,6 @@
 import dlt
 
-from github import github_reactions, github_repo_events
+from github import github_reactions, github_repo_events, github_stargazers
 
 
 def load_duckdb_repo_reactions_issues_only() -> None:
@@ -42,7 +42,20 @@ def load_dlthub_dlt_all_data() -> None:
     print(pipeline.run(data))
 
 
+def load_dlthub_dlt_stargazers() -> None:
+    """Loads all stargazers for dlthub dlt repo"""
+    pipeline = dlt.pipeline(
+        "github_staragarzers",
+        destination="duckdb",
+        dataset_name="dlthub_staragarzers",
+        full_refresh=True,
+    )
+    data = github_stargazers("dlt-hub", "dlt")
+    print(pipeline.run(data))
+
+
 if __name__ == "__main__":
     load_duckdb_repo_reactions_issues_only()
     load_airflow_events()
     load_dlthub_dlt_all_data()
+    load_dlthub_dlt_stargazers()

--- a/tests/github/test_github_source.py
+++ b/tests/github/test_github_source.py
@@ -2,7 +2,7 @@ import pytest
 
 import dlt
 
-from sources.github import github_reactions, github_repo_events
+from sources.github import github_reactions, github_repo_events, github_stargazers
 
 from tests.utils import (
     ALL_DESTINATIONS,
@@ -78,3 +78,29 @@ def test_github_events(destination_name: str) -> None:
     table_distinct_id_counts = load_table_distinct_counts(pipeline, "id", *table_names)
     # no duplicates
     assert table_counts == table_distinct_id_counts
+
+
+@pytest.mark.parametrize("destination_name", ALL_DESTINATIONS)
+def test_github_stargazers(destination_name: str) -> None:
+    pipeline = dlt.pipeline(
+        "github_stargazers",
+        destination=destination_name,
+        dataset_name="duckdb_stargazers",
+        full_refresh=True,
+    )
+    # get only 100 stargazers
+    data = github_stargazers("duckdb", "duckdb", items_per_page=100, max_items=100)
+    load_info = pipeline.run(data)
+    assert_load_info(load_info)
+    # assert tables created
+    expected_tables = ["stargazers"]
+    # only those tables in the schema
+    assert set(t["name"] for t in pipeline.default_schema.data_tables()) == set(
+        expected_tables
+    )
+    # get counts
+    table_counts = load_table_counts(pipeline, *expected_tables)
+    # all tables loaded
+    assert set(table_counts.keys()) == set(expected_tables)
+    assert all(c > 0 for c in table_counts.values())
+    assert table_counts["stargazers"] == 100


### PR DESCRIPTION
### Tell us what you do here
<!--
Pick the relevant item or items and remove the rest: 
-->
- [x] improving, documenting, or customizing an existing source (please link an issue or describe below)

### Short description

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
This PR adds a new resource for github stargazers. It provides the github user info (login, url, avatar) and the starred_at for every repo. The data is fetched using graphql and the full history is available.


### Related Issues
not related to any issue

### Additional Context

- not related to this PR but I was not able to install the pre-requisites with python 3.12 : multidict is not compatible, so I have moved to 3.8 as suggested by the contribution guideline
- unfortunately it is not possible to get forks/watchers with date from github graphql api
