### PR TITLE
allows SqlAlchemy engine to be passed to sql_table

### DIFF
--- a/sources/sql_database/helpers.py
+++ b/sources/sql_database/helpers.py
@@ -261,10 +261,14 @@ class SqlDatabaseTableConfiguration(BaseConfiguration):
 
 @configspec
 class SqlTableResourceConfiguration(BaseConfiguration):
-    credentials: ConnectionStringCredentials = None
+    credentials: Union[ConnectionStringCredentials, Engine, str] = None
     table: str = None
     incremental: Optional[dlt.sources.incremental] = None  # type: ignore[type-arg]
     schema: Optional[str] = None
+    chunk_size: int = 50000
+    backend: TableBackend = "sqlalchemy"
+    detect_precision_hints: Optional[bool] = False
+    defer_table_reflect: Optional[bool] = False
 
 
 __source_name__ = "sql_database"

--- a/tests/sql_database/test_sql_database_source.py
+++ b/tests/sql_database/test_sql_database_source.py
@@ -35,6 +35,20 @@ def make_pipeline(destination_name: str) -> dlt.Pipeline:
     )
 
 
+def test_pass_engine_credentials(sql_source_db: SQLAlchemySourceDB) -> None:
+    # verify database
+    database = sql_database(
+        sql_source_db.engine, schema=sql_source_db.schema, table_names=["chat_message"]
+    )
+    assert len(list(database)) == sql_source_db.table_infos["chat_message"]["row_count"]
+
+    # verify table
+    table = sql_table(
+        sql_source_db.engine, table="chat_message", schema=sql_source_db.schema
+    )
+    assert len(list(table)) == sql_source_db.table_infos["chat_message"]["row_count"]
+
+
 @pytest.mark.parametrize("destination_name", ALL_DESTINATIONS)
 @pytest.mark.parametrize("backend", ["sqlalchemy", "pandas", "pyarrow", "connectorx"])
 def test_load_sql_schema_loads_all_tables(


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Tell us what you do here
<!--
Pick the relevant item or items and remove the rest: 
-->
- fixing a bug (please link a relevant bug report)

### Short description
Outdated `configspec` was preventing `sql_table` method to accept `Engine` instances. This is fixed here - extracted form a larger PR #478 