### PR TITLE
fix: `pg_replication` example pipeline issues

### DIFF
--- a/sources/pg_replication/exceptions.py
+++ b/sources/pg_replication/exceptions.py
@@ -4,3 +4,11 @@ class NoPrimaryKeyException(Exception):
 
 class IncompatiblePostgresVersionException(Exception):
     pass
+
+
+class SqlDatabaseSourceImportError(Exception):
+    def __init__(self) -> None:
+        super().__init__(
+            "Could not import `sql_database` source. Run `dlt init sql_database <dest>`"
+            " to download the source code."
+        )

--- a/sources/pg_replication/helpers.py
+++ b/sources/pg_replication/helpers.py
@@ -35,11 +35,6 @@ from dlt.extract.items import DataItemWithMeta
 from dlt.extract.resource import DltResource
 from dlt.sources.credentials import ConnectionStringCredentials
 
-try:
-    from ..sql_database import sql_table  # type: ignore[import-untyped]
-except Exception:
-    from sql_database import sql_table
-
 from .schema_types import _to_dlt_column_schema, _to_dlt_val
 from .exceptions import IncompatiblePostgresVersionException
 from .decoders import (
@@ -367,6 +362,16 @@ def snapshot_table_resource(
     Can be used to perform an initial load of the table, so all data that
     existed in the table prior to initializing replication is also captured.
     """
+    try:
+        from ..sql_database import sql_table  # type: ignore[import-untyped]
+    except Exception:
+        try:
+            from sql_database import sql_table
+        except ImportError as e:
+            from .exceptions import SqlDatabaseSourceImportError
+
+            raise SqlDatabaseSourceImportError from e
+
     resource: DltResource = sql_table(
         credentials=credentials,
         table=snapshot_table_name,

--- a/sources/pg_replication/helpers.py
+++ b/sources/pg_replication/helpers.py
@@ -469,7 +469,7 @@ def _get_conn(
         host=credentials.host,
         port=credentials.port,
         connection_factory=connection_factory,
-        **credentials.query,
+        **({} if credentials.query is None else credentials.query),
     )
 
 

--- a/sources/pg_replication/requirements.txt
+++ b/sources/pg_replication/requirements.txt
@@ -1,2 +1,2 @@
-dlt>=0.4.8
+dlt>=0.4.13
 psycopg2-binary>=2.9.9

--- a/sources/pg_replication_pipeline.py
+++ b/sources/pg_replication_pipeline.py
@@ -1,8 +1,12 @@
 import dlt
 
+from dlt.destinations.impl.postgres.configuration import PostgresCredentials
 
 from pg_replication import replication_resource
 from pg_replication.helpers import init_replication
+
+
+PG_CREDS = dlt.secrets.get("sources.pg_replication.credentials", PostgresCredentials)
 
 
 def replicate_single_table() -> None:
@@ -255,7 +259,7 @@ def replicate_with_column_selection() -> None:
 def create_source_table(
     src_pl: dlt.Pipeline, sql: str, table_name: str = "my_source_table"
 ) -> None:
-    with src_pl.sql_client() as c:
+    with src_pl.sql_client(credentials=PG_CREDS) as c:
         try:
             c.create_dataset()
         except dlt.destinations.exceptions.DatabaseTerminalException:
@@ -267,7 +271,7 @@ def create_source_table(
 def change_source_table(
     src_pl: dlt.Pipeline, sql: str, table_name: str = "my_source_table"
 ) -> None:
-    with src_pl.sql_client() as c:
+    with src_pl.sql_client(credentials=PG_CREDS) as c:
         qual_name = c.make_qualified_table_name(table_name)
         c.execute_sql(sql.format(table_name=qual_name))
 

--- a/sources/pg_replication_pipeline.py
+++ b/sources/pg_replication_pipeline.py
@@ -1,5 +1,6 @@
 import dlt
 
+from dlt.common.destination import Destination
 from dlt.destinations.impl.postgres.configuration import PostgresCredentials
 
 from pg_replication import replication_resource
@@ -18,12 +19,7 @@ def replicate_single_table() -> None:
     as you'll probably have another process feeding your Postgres instance.
     """
     # create source and destination pipelines
-    src_pl = dlt.pipeline(
-        pipeline_name="source_pipeline",
-        destination="postgres",
-        dataset_name="replicate_single_table",
-        dev_mode=True,
-    )
+    src_pl = get_postgres_pipeline()
     dest_pl = dlt.pipeline(
         pipeline_name="pg_replication_pipeline",
         destination="duckdb",
@@ -75,12 +71,7 @@ def replicate_with_initial_load() -> None:
     returned by `init_replication` helper.
     """
     # create source and destination pipelines
-    src_pl = dlt.pipeline(
-        pipeline_name="source_pipeline",
-        destination="postgres",
-        dataset_name="replicate_with_initial_load",
-        dev_mode=True,
-    )
+    src_pl = get_postgres_pipeline()
     dest_pl = dlt.pipeline(
         pipeline_name="pg_replication_pipeline",
         destination="duckdb",
@@ -128,12 +119,7 @@ def replicate_entire_schema() -> None:
     exception is raised if that's not the case.
     """
     # create source and destination pipelines
-    src_pl = dlt.pipeline(
-        pipeline_name="source_pipeline",
-        destination="postgres",
-        dataset_name="replicate_entire_schema",
-        dev_mode=True,
-    )
+    src_pl = get_postgres_pipeline()
     dest_pl = dlt.pipeline(
         pipeline_name="pg_replication_pipeline",
         destination="duckdb",
@@ -192,12 +178,7 @@ def replicate_with_column_selection() -> None:
     Demonstrates usage of `include_columns` argument.
     """
     # create source and destination pipelines
-    src_pl = dlt.pipeline(
-        pipeline_name="source_pipeline",
-        destination="postgres",
-        dataset_name="replicate_with_column_selection",
-        dev_mode=True,
-    )
+    src_pl = get_postgres_pipeline()
     dest_pl = dlt.pipeline(
         pipeline_name="pg_replication_pipeline",
         destination="duckdb",
@@ -254,6 +235,22 @@ def replicate_with_column_selection() -> None:
 
 
 # define some helper methods to make examples more readable
+
+
+def get_postgres_pipeline() -> dlt.Pipeline:
+    """Returns a pipeline loading into `postgres` destination.
+
+    Uses workaround to fix destination to `postgres`, so it does not get replaced
+    during `dlt init`.
+    """
+    src_pl = dlt.pipeline(
+        pipeline_name="source_pipeline",
+        # destination="postgres",  # don't use this, `dlt init` replaces this
+        dataset_name="source_dataset",
+        dev_mode=True,
+    )
+    src_pl.destination = Destination.from_reference("postgres")  # use this instead
+    return src_pl
 
 
 def create_source_table(

--- a/sources/pg_replication_pipeline.py
+++ b/sources/pg_replication_pipeline.py
@@ -24,7 +24,7 @@ def replicate_single_table() -> None:
         pipeline_name="pg_replication_pipeline",
         destination="duckdb",
         dataset_name="replicate_single_table",
-        dev_mode=True,
+        full_refresh=True,
     )
 
     # create table "my_source_table" in source to demonstrate replication
@@ -76,7 +76,7 @@ def replicate_with_initial_load() -> None:
         pipeline_name="pg_replication_pipeline",
         destination="duckdb",
         dataset_name="replicate_with_initial_load",
-        dev_mode=True,
+        full_refresh=True,
     )
 
     # create table "my_source_table" in source to demonstrate replication
@@ -124,7 +124,7 @@ def replicate_entire_schema() -> None:
         pipeline_name="pg_replication_pipeline",
         destination="duckdb",
         dataset_name="replicate_entire_schema",
-        dev_mode=True,
+        full_refresh=True,
     )
 
     # create two source tables to demonstrate schema replication
@@ -183,7 +183,7 @@ def replicate_with_column_selection() -> None:
         pipeline_name="pg_replication_pipeline",
         destination="duckdb",
         dataset_name="replicate_with_column_selection",
-        dev_mode=True,
+        full_refresh=True,
     )
 
     # create two source tables to demonstrate schema replication
@@ -247,7 +247,7 @@ def get_postgres_pipeline() -> dlt.Pipeline:
         pipeline_name="source_pipeline",
         # destination="postgres",  # don't use this, `dlt init` replaces this
         dataset_name="source_dataset",
-        dev_mode=True,
+        full_refresh=True,
     )
     pipe.destination = Destination.from_reference("postgres")  # use this instead
     return pipe

--- a/sources/pg_replication_pipeline.py
+++ b/sources/pg_replication_pipeline.py
@@ -243,14 +243,14 @@ def get_postgres_pipeline() -> dlt.Pipeline:
     Uses workaround to fix destination to `postgres`, so it does not get replaced
     during `dlt init`.
     """
-    src_pl = dlt.pipeline(
+    pipe = dlt.pipeline(
         pipeline_name="source_pipeline",
         # destination="postgres",  # don't use this, `dlt init` replaces this
         dataset_name="source_dataset",
         dev_mode=True,
     )
-    src_pl.destination = Destination.from_reference("postgres")  # use this instead
-    return src_pl
+    pipe.destination = Destination.from_reference("postgres")  # use this instead
+    return pipe
 
 
 def create_source_table(

--- a/sources/pg_replication_pipeline.py
+++ b/sources/pg_replication_pipeline.py
@@ -18,13 +18,13 @@ def replicate_single_table() -> None:
         pipeline_name="source_pipeline",
         destination="postgres",
         dataset_name="replicate_single_table",
-        full_refresh=True,
+        dev_mode=True,
     )
     dest_pl = dlt.pipeline(
         pipeline_name="pg_replication_pipeline",
         destination="duckdb",
         dataset_name="replicate_single_table",
-        full_refresh=True,
+        dev_mode=True,
     )
 
     # create table "my_source_table" in source to demonstrate replication
@@ -75,13 +75,13 @@ def replicate_with_initial_load() -> None:
         pipeline_name="source_pipeline",
         destination="postgres",
         dataset_name="replicate_with_initial_load",
-        full_refresh=True,
+        dev_mode=True,
     )
     dest_pl = dlt.pipeline(
         pipeline_name="pg_replication_pipeline",
         destination="duckdb",
         dataset_name="replicate_with_initial_load",
-        full_refresh=True,
+        dev_mode=True,
     )
 
     # create table "my_source_table" in source to demonstrate replication
@@ -128,13 +128,13 @@ def replicate_entire_schema() -> None:
         pipeline_name="source_pipeline",
         destination="postgres",
         dataset_name="replicate_entire_schema",
-        full_refresh=True,
+        dev_mode=True,
     )
     dest_pl = dlt.pipeline(
         pipeline_name="pg_replication_pipeline",
         destination="duckdb",
         dataset_name="replicate_entire_schema",
-        full_refresh=True,
+        dev_mode=True,
     )
 
     # create two source tables to demonstrate schema replication
@@ -192,13 +192,13 @@ def replicate_with_column_selection() -> None:
         pipeline_name="source_pipeline",
         destination="postgres",
         dataset_name="replicate_with_column_selection",
-        full_refresh=True,
+        dev_mode=True,
     )
     dest_pl = dlt.pipeline(
         pipeline_name="pg_replication_pipeline",
         destination="duckdb",
         dataset_name="replicate_with_column_selection",
-        full_refresh=True,
+        dev_mode=True,
     )
 
     # create two source tables to demonstrate schema replication

--- a/tests/test_dlt_init.py
+++ b/tests/test_dlt_init.py
@@ -87,7 +87,14 @@ def assert_pipeline_files(
     )
     # check destinations
     for args in visitor.known_calls[n.PIPELINE]:
-        assert args.arguments["destination"].value == destination_name
+        destination = args.arguments["destination"]
+        if pipeline_name == "pg_replication":
+            # allow None as `pg_replication` uses a workaround in its example
+            # pipeline to fix the destination such that it does not get replaced
+            # during `dlt init`
+            assert destination is None or destination.value == destination_name
+        else:
+            assert destination.value == destination_name
     # load secrets
     secrets = SecretsTomlProvider()
     if destination_name != "duckdb":


### PR DESCRIPTION
Fixes https://github.com/dlt-hub/dlt/issues/1490

- makes `sql_table` import from external `sql_database` source conditional on `persist_snapshots` argument, so users only have to run `dlt init sql_database ...` if they want to do an initial load
- fixes destination for "source pipeline" in example pipelines to `postgres` using workaround, so it doesn't get replaced during `dlt init` 
- adds explicit `credentials` argument when creating `sql_client` from `Pipeline` object, so no `destinations.postgres.credentials` block is included in the generated `secrets.toml` 
  - bumps `dlt` requirement to version `0.13`, because it relies on the fix in https://github.com/dlt-hub/dlt/pull/1499/files 
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 