### PR TITLE
rest_api: Fix/518 prevent unsupported incremental configs

### DIFF
--- a/sources/rest_api/config_setup.py
+++ b/sources/rest_api/config_setup.py
@@ -158,28 +158,36 @@ def setup_incremental_object(
     Optional[Incremental[Any]], Optional[IncrementalParam], Optional[Callable[..., Any]]
 ]:
     incremental_params: List[str] = []
-    for key, value in request_params.items():
+    for param_name, param_config in request_params.items():
         if (
-            isinstance(value, dict)
-            and value.get("type") == "incremental"
-            or isinstance(value, dlt.sources.incremental)
+            isinstance(param_config, dict)
+            and param_config.get("type") == "incremental"
+            or isinstance(param_config, dlt.sources.incremental)
         ):
-            incremental_params.append(key)
+            incremental_params.append(param_name)
     if len(incremental_params) > 1:
         raise ValueError(
             f"Only a single incremental parameter is allower per endpoint. Found: {incremental_params}"
         )
     transform: Optional[Callable[..., Any]]
-    for key, value in request_params.items():
-        if isinstance(value, dlt.sources.incremental):
-            return value, IncrementalParam(start=key, end=None), None
-        if isinstance(value, dict) and value.get("type") == "incremental":
-            transform = value.get("transform", None)
-            config = exclude_keys(value, {"type", "transform"})
+    for param_name, param_config in request_params.items():
+        if isinstance(param_config, dlt.sources.incremental):
+            if param_config.end_value is not None:
+                raise ValueError(
+                    f"Only initial_value is allowed in the configuration of param: {param_name}. To set end_value too use the incremental configuration at the resource level. See https://dlthub.com/docs/dlt-ecosystem/verified-sources/rest_api#incremental-loading/"
+                )
+            return param_config, IncrementalParam(start=param_name, end=None), None
+        if isinstance(param_config, dict) and param_config.get("type") == "incremental":
+            if param_config.get("end_value") or param_config.get("end_param"):
+                raise ValueError(
+                    f"Only start_param and initial_value are allowed in the configuration of param: {param_name}. To set end_value too use the incremental configuration at the resource level. See https://dlthub.com/docs/dlt-ecosystem/verified-sources/rest_api#incremental-loading"
+                )
+            transform = param_config.get("transform", None)
+            config = exclude_keys(param_config, {"type", "transform"})
             # TODO: implement param type to bind incremental to
             return (
                 dlt.sources.incremental(**config),
-                IncrementalParam(start=key, end=None),
+                IncrementalParam(start=param_name, end=None),
                 transform,
             )
     if incremental_config:

--- a/sources/rest_api/config_setup.py
+++ b/sources/rest_api/config_setup.py
@@ -159,7 +159,11 @@ def setup_incremental_object(
 ]:
     incremental_params: List[str] = []
     for key, value in request_params.items():
-        if isinstance(value, dict) and value.get("type") == "incremental":
+        if (
+            isinstance(value, dict)
+            and value.get("type") == "incremental"
+            or isinstance(value, dlt.sources.incremental)
+        ):
             incremental_params.append(key)
     if len(incremental_params) > 1:
         raise ValueError(

--- a/tests/rest_api/test_configurations.py
+++ b/tests/rest_api/test_configurations.py
@@ -612,6 +612,24 @@ def test_one_resource_cannot_have_many_incrementals() -> None:
     assert e.match(error_message)
 
 
+def test_one_resource_cannot_have_many_incrementals_2(incremental_with_init) -> None:
+    request_params = {
+        "foo": "bar",
+        "first_incremental": {
+            "type": "incremental",
+            "cursor_path": "created_at",
+            "initial_value": "2024-02-02T00:00:00Z",
+        },
+        "second_incremental": incremental_with_init,
+    }
+    with pytest.raises(ValueError) as e:
+        setup_incremental_object(request_params)
+    error_message = re.escape(
+        "Only a single incremental parameter is allower per endpoint. Found: ['first_incremental', 'second_incremental']"
+    )
+    assert e.match(error_message)
+
+
 def test_constructs_incremental_from_request_param() -> None:
     request_params = {
         "foo": "bar",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Tell us what you do here
<!--
Pick the relevant item or items and remove the rest: 
-->
- implementing verified source (please link a relevant issue labeled as `verified source`)
- fixing a bug (please link a relevant bug report)
- improving, documenting, or customizing an existing source (please link an issue or describe below)
- anything else (please link an issue or describe below)

### Short description
- fixes bug where configuring two incremental configs in one endpoint resource would not raise an error
- throws error if request param is configured with unsupported and illogical incremental config

### Related Issues

- Resolves #518 

### Additional Context


