### PR TITLE
Fix: 1616 makes it possible to configure the base_page for PageNumberPaginator

### DIFF
--- a/sources/rest_api/typing.py
+++ b/sources/rest_api/typing.py
@@ -60,7 +60,7 @@ class PaginatorTypeConfig(TypedDict, total=True):
 class PageNumberPaginatorConfig(PaginatorTypeConfig, total=False):
     """A paginator that uses page number-based pagination strategy."""
 
-    initial_page: Optional[int]
+    base_page: Optional[int]
     page_param: Optional[str]
     total_path: Optional[jsonpath.TJsonPath]
     maximum_page: Optional[int]

--- a/tests/rest_api/test_configurations.py
+++ b/tests/rest_api/test_configurations.py
@@ -114,6 +114,7 @@ def test_paginator_type_configs(paginator_type_config: PaginatorTypeConfig) -> N
             assert paginator.links_next_key == "next_page"
         if isinstance(paginator, PageNumberPaginator):
             assert paginator.current_value == 10
+            assert paginator.base_index == 1
             assert paginator.param_name == "page"
             assert paginator.total_path == compile_path("response.pages")
             assert paginator.maximum_value is None
@@ -134,6 +135,26 @@ def test_paginator_type_configs(paginator_type_config: PaginatorTypeConfig) -> N
 def test_paginator_instance_config() -> None:
     paginator = OffsetPaginator(limit=100)
     assert create_paginator(paginator) is paginator
+
+
+def test_page_number_paginator_creation() -> None:
+    config: RESTAPIConfig = {  # type: ignore
+        "client": {
+            "base_url": "https://api.example.com",
+            "paginator": {
+                "type": "page_number",
+                "page_param": "foobar",
+                "total_path": "response.pages",
+                "base_page": 1,
+                "maximum_page": 5,
+            },
+        },
+        "resources": ["posts"],
+    }
+    try:
+        rest_api_source(config)
+    except dlt.common.exceptions.DictValidationException:
+        pytest.fail("DictValidationException was unexpectedly raised")
 
 
 @pytest.mark.parametrize("auth_type", get_args(AuthType))


### PR DESCRIPTION
### Short description

This PR:
- Corrects the type declaration of the PageNumberPaginator
- updates the existing test
- includes a regression test

### Related Issues

- Fixes https://github.com/dlt-hub/dlt/issues/1616

### Additional Context

<!--
Please ensure that
    - you have read the [Contributing Guide](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
