### PR TITLE
rest_api paginator: Allows using json_response in place of json_link

### DIFF
--- a/sources/rest_api/config_setup.py
+++ b/sources/rest_api/config_setup.py
@@ -37,7 +37,7 @@ from dlt.sources.helpers.rest_client.paginators import (
 try:
     from dlt.sources.helpers.rest_client.paginators import JSONLinkPaginator
 except ImportError:
-    from dlt.sources.helpers.rest_client.paginators import JSONResponsePaginator as JSONLinkPaginator # type: ignore
+    from dlt.sources.helpers.rest_client.paginators import JSONResponsePaginator as JSONLinkPaginator  # type: ignore
 
 from dlt.sources.helpers.rest_client.detector import single_entity_path
 from dlt.sources.helpers.rest_client.exceptions import IgnoreResponseException
@@ -66,6 +66,7 @@ from .utils import exclude_keys
 
 PAGINATOR_MAP: Dict[PaginatorType, Type[BasePaginator]] = {
     "json_link": JSONLinkPaginator,
+    "json_response": JSONLinkPaginator,  # deprecated. Use json_link instead. Will be removed in upcoming release
     "header_link": HeaderLinkPaginator,
     "auto": None,
     "single_page": SinglePagePaginator,

--- a/sources/rest_api/typing.py
+++ b/sources/rest_api/typing.py
@@ -38,7 +38,7 @@ from dlt.sources.helpers.rest_client.paginators import (
 try:
     from dlt.sources.helpers.rest_client.paginators import JSONLinkPaginator
 except ImportError:
-    from dlt.sources.helpers.rest_client.paginators import JSONResponsePaginator as JSONLinkPaginator # type: ignore
+    from dlt.sources.helpers.rest_client.paginators import JSONResponsePaginator as JSONLinkPaginator  # type: ignore
 
 from dlt.sources.helpers.rest_client.auth import (
     AuthConfigBase,
@@ -49,6 +49,7 @@ from dlt.sources.helpers.rest_client.auth import (
 
 PaginatorType = Literal[
     "json_link",
+    "json_response",  # deprecated. Use json_link instead. Will be removed in upcoming release
     "header_link",
     "auto",
     "single_page",

--- a/tests/rest_api/test_configurations.py
+++ b/tests/rest_api/test_configurations.py
@@ -164,7 +164,7 @@ def test_page_number_paginator_creation() -> None:
         pytest.fail("DictValidationException was unexpectedly raised")
 
 
-def test_json_link_paginator(mock_api_server) -> None:
+def test_allow_deprecated_json_response_paginator(mock_api_server) -> None:
     """
     Delete this test as soon as we stop supporting the deprecated key json_response
     for the JSONLinkPaginator

--- a/tests/rest_api/test_configurations.py
+++ b/tests/rest_api/test_configurations.py
@@ -60,7 +60,9 @@ from dlt.sources.helpers.rest_client.paginators import (
 try:
     from dlt.sources.helpers.rest_client.paginators import JSONLinkPaginator
 except ImportError:
-    from dlt.sources.helpers.rest_client.paginators import JSONResponsePaginator as JSONLinkPaginator
+    from dlt.sources.helpers.rest_client.paginators import (
+        JSONResponsePaginator as JSONLinkPaginator,
+    )
 
 
 from dlt.sources.helpers.rest_client.auth import (
@@ -160,6 +162,30 @@ def test_page_number_paginator_creation() -> None:
         rest_api_source(config)
     except dlt.common.exceptions.DictValidationException:
         pytest.fail("DictValidationException was unexpectedly raised")
+
+
+def test_json_link_paginator(mock_api_server) -> None:
+    """
+    Delete this test as soon as we stop supporting the deprecated key json_response
+    for the JSONLinkPaginator
+    """
+    config: RESTAPIConfig = { # type: ignore
+        "client": {"base_url": "https://api.example.com"},
+        "resources": [
+            {
+                "name": "posts",
+                "endpoint": {
+                    "path": "posts",
+                    "paginator": {
+                        "type": "json_response",
+                        "next_url_path": "links.next",
+                    },
+                },
+            },
+        ],
+    }
+
+    rest_api_source(config)
 
 
 @pytest.mark.parametrize("auth_type", get_args(AuthType))


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Tell us what you do here
- fixing a bug:
- code formatting

### Short description

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #...
- Closes #...
- Resolves #...

### Additional Context

<!--
Please ensure that
    - you have read the [Contributing Guide](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
