### PR TITLE
fix/sql_database/handles JSON type for arrow and represents UUID as string

### DIFF
--- a/sources/sql_database/__init__.py
+++ b/sources/sql_database/__init__.py
@@ -20,6 +20,7 @@ from .helpers import (
     _detect_precision_hints_deprecated,
 )
 from .schema_types import (
+    default_table_adapter,
     table_to_columns,
     get_primary_key,
     ReflectionLevel,
@@ -100,8 +101,10 @@ def sql_database(
         tables = list(metadata.tables.values())
 
     for table in tables:
-        if table_adapter_callback and not defer_table_reflect:
-            table_adapter_callback(table)
+        if not defer_table_reflect:
+            default_table_adapter(table)
+            if table_adapter_callback:
+                table_adapter_callback(table)
 
         yield dlt.resource(
             table_rows,
@@ -185,8 +188,10 @@ def sql_table(
     table_obj = Table(
         table, metadata, autoload_with=None if defer_table_reflect else engine
     )
-    if table_adapter_callback and not defer_table_reflect:
-        table_adapter_callback(table_obj)
+    if not defer_table_reflect:
+        default_table_adapter(table_obj)
+        if table_adapter_callback:
+            table_adapter_callback(table_obj)
 
     return dlt.resource(
         table_rows,

--- a/sources/sql_database/helpers.py
+++ b/sources/sql_database/helpers.py
@@ -23,6 +23,7 @@ from dlt.sources.credentials import ConnectionStringCredentials
 
 from .arrow_helpers import row_tuples_to_arrow
 from .schema_types import (
+    default_table_adapter,
     table_to_columns,
     get_primary_key,
     Table,
@@ -194,6 +195,7 @@ def table_rows(
         table = Table(
             table.name, table.metadata, autoload_with=engine, extend_existing=True
         )
+        default_table_adapter(table)
         if table_adapter_callback:
             table_adapter_callback(table)
         columns = table_to_columns(table, reflection_level, type_adapter_callback)

--- a/tests/sql_database/sql_source.py
+++ b/tests/sql_database/sql_source.py
@@ -1,6 +1,7 @@
 from typing import List, TypedDict, Dict
 import random
 from copy import deepcopy
+from uuid import uuid4
 
 import mimesis
 from sqlalchemy import (
@@ -27,8 +28,9 @@ from sqlalchemy import (
     Time,
     JSON,
     ARRAY,
+    Uuid,
 )
-from sqlalchemy.dialects.postgresql import DATERANGE
+from sqlalchemy.dialects.postgresql import DATERANGE, JSONB
 
 from dlt.common.utils import chunks, uniq_id
 from dlt.sources.credentials import ConnectionStringCredentials
@@ -160,8 +162,9 @@ class SQLAlchemySourceDB:
                 Column("date_col", Date, nullable=nullable),
                 Column("time_col", Time, nullable=nullable),
                 Column("float_col", Float, nullable=nullable),
-                Column("json_col", JSON, nullable=nullable),
+                Column("json_col", JSONB, nullable=nullable),
                 Column("bool_col", Boolean, nullable=nullable),
+                Column("uuid_col", Uuid, nullable=nullable),
             )
 
         _make_precision_table("has_precision", False)
@@ -310,8 +313,9 @@ class SQLAlchemySourceDB:
                 date_col=mimesis.Datetime().date(),
                 time_col=mimesis.Datetime().time(),
                 float_col=random.random(),
-                json_col="[1, 2, 3]",
+                json_col={"data": [1, 2, 3]},
                 bool_col=random.randint(0, 1) == 1,
+                uuid_col=uuid4(),
             )
             for _ in range(n + null_n)
         ]

--- a/tests/sql_database/test_sql_database_source.py
+++ b/tests/sql_database/test_sql_database_source.py
@@ -721,7 +721,10 @@ def test_all_types_with_precision_hints(
     table = schema.tables[table_name]
     assert_precision_columns(table["columns"], backend, nullable)
     assert_schema_on_data(
-        table, load_tables_to_dicts(pipeline, table_name)[table_name], nullable
+        table,
+        load_tables_to_dicts(pipeline, table_name)[table_name],
+        nullable,
+        backend in ["sqlalchemy", "pyarrow"],
     )
 
 
@@ -756,7 +759,10 @@ def test_all_types_no_precision_hints(
     table = schema.tables[table_name]
     assert_no_precision_columns(table["columns"], backend, nullable)
     assert_schema_on_data(
-        table, load_tables_to_dicts(pipeline, table_name)[table_name], nullable
+        table,
+        load_tables_to_dicts(pipeline, table_name)[table_name],
+        nullable,
+        backend in ["sqlalchemy", "pyarrow"],
     )
 
 
@@ -859,6 +865,7 @@ def test_deferred_reflect_in_source(
         precision_table,
         load_tables_to_dicts(pipeline, "has_precision")["has_precision"],
         True,
+        backend in ["sqlalchemy", "pyarrow"],
     )
     assert len(source.chat_message.columns) > 0  # type: ignore[arg-type]
     assert (
@@ -917,6 +924,7 @@ def test_deferred_reflect_in_resource(
         precision_table,
         load_tables_to_dicts(pipeline, "has_precision")["has_precision"],
         True,
+        backend in ["sqlalchemy", "pyarrow"],
     )
 
 
@@ -1335,6 +1343,10 @@ PRECISION_COLUMNS: List[TColumnSchema] = [
     {
         "data_type": "bool",
         "name": "bool_col",
+    },
+    {
+        "data_type": "text",
+        "name": "uuid_col",
     },
 ]
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -275,7 +275,10 @@ def load_tables_to_dicts(
 
 
 def assert_schema_on_data(
-    table_schema: TTableSchema, rows: List[Dict[str, Any]], requires_nulls: bool
+    table_schema: TTableSchema,
+    rows: List[Dict[str, Any]],
+    requires_nulls: bool,
+    check_complex: bool,
 ) -> None:
     """Asserts that `rows` conform to `table_schema`. Fields and their order must conform to columns. Null values and
     python data types are checked.
@@ -299,7 +302,12 @@ def assert_schema_on_data(
             expected_dt = table_columns[key]["data_type"]
             # allow complex strings
             if expected_dt == "complex":
-                value = json.loads(value)
+                if check_complex:
+                    # NOTE: we expect a dict or a list here. simple types of null will fail the test
+                    value = json.loads(value)
+                else:
+                    # skip checking complex types
+                    continue
             actual_dt = py_type_to_sc_type(type(value))
             assert actual_dt == expected_dt
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Tell us what you do here
<!--
Pick the relevant item or items and remove the rest: 
-->
- fixing a bug (please link a relevant bug report)

### Short description
1. JSON fields were not correctly serialized before forming arrow tables and in some cases extraction failed. NOTE: **pandas** and **connectorx** does not handle such fields at all - they convert those values to string without json serialization. We are not fixing this here. docs will be updated
2. UUIDs were left as unknow types and handled by the particular backend. Now the UUIDs are represented as string.