### PR TITLE
rest_api: mask secrets in config

### DIFF
--- a/sources/rest_api/__init__.py
+++ b/sources/rest_api/__init__.py
@@ -46,6 +46,13 @@ from .config_setup import (
 from .utils import check_connection, exclude_keys  # noqa: F401
 
 PARAM_TYPES: List[ParamBindType] = ["incremental", "resolve"]
+MIN_SECRET_MASKING_LENGTH = 3
+SENSITIVE_KEYS: List[str] = [
+    "token",
+    "api_key",
+    "username",
+    "password",
+]
 
 
 def rest_api_source(
@@ -387,14 +394,6 @@ def _mask_secrets(auth_config: AuthConfig) -> AuthConfig:
     return auth_config
 
 
-SENSITIVE_KEYS: List[str] = [
-    "token",
-    "api_key",
-    "username",
-    "password",
-]
-
-
 def _mask_secrets_dict(auth_config: AuthConfig) -> AuthConfig:
     for sensitive_key in SENSITIVE_KEYS:
         try:
@@ -407,7 +406,7 @@ def _mask_secrets_dict(auth_config: AuthConfig) -> AuthConfig:
 def _mask_secret(secret: Optional[str]) -> str:
     if secret is None:
         return "None"
-    if len(secret) < 3:
+    if len(secret) < MIN_SECRET_MASKING_LENGTH:
         return "*****"
     return f"{secret[0]}*****{secret[-1]}"
 

--- a/sources/rest_api/__init__.py
+++ b/sources/rest_api/__init__.py
@@ -357,12 +357,12 @@ def _validate_config(config: RESTAPIConfig) -> None:
     if client_config:
         auth = client_config.get("auth")
         if auth:
-            _mask_secrets(auth)
+            auth = _mask_secrets(auth)
 
     validate_dict(RESTAPIConfig, c, path=".")
 
 
-def _mask_secrets(auth_config: AuthConfig) -> None:
+def _mask_secrets(auth_config: AuthConfig) -> AuthConfig:
     sensitive_keys = [
         "token",
         "api_key",
@@ -377,6 +377,7 @@ def _mask_secrets(auth_config: AuthConfig) -> None:
             auth_config[sensitive_key] = _mask_secret(auth_config[sensitive_key])  # type: ignore[literal-required, index]
         except KeyError:
             continue
+    return auth_config
 
 
 def _mask_secret(secret: Optional[str]) -> str:

--- a/sources/rest_api/config_setup.py
+++ b/sources/rest_api/config_setup.py
@@ -38,7 +38,9 @@ from dlt.sources.helpers.rest_client.paginators import (
 try:
     from dlt.sources.helpers.rest_client.paginators import JSONLinkPaginator
 except ImportError:
-    from dlt.sources.helpers.rest_client.paginators import JSONResponsePaginator as JSONLinkPaginator
+    from dlt.sources.helpers.rest_client.paginators import (
+        JSONResponsePaginator as JSONLinkPaginator,
+    )
 
 from dlt.sources.helpers.rest_client.detector import single_entity_path
 from dlt.sources.helpers.rest_client.exceptions import IgnoreResponseException

--- a/sources/rest_api/typing.py
+++ b/sources/rest_api/typing.py
@@ -38,7 +38,9 @@ from dlt.sources.helpers.rest_client.paginators import (
 try:
     from dlt.sources.helpers.rest_client.paginators import JSONLinkPaginator
 except ImportError:
-    from dlt.sources.helpers.rest_client.paginators import JSONResponsePaginator as JSONLinkPaginator
+    from dlt.sources.helpers.rest_client.paginators import (
+        JSONResponsePaginator as JSONLinkPaginator,
+    )
 
 from dlt.sources.helpers.rest_client.auth import (
     AuthConfigBase,

--- a/tests/rest_api/test_configurations.py
+++ b/tests/rest_api/test_configurations.py
@@ -1423,6 +1423,8 @@ def test_resource_defaults_no_params() -> None:
         "per_page": 50,
         "sort": "updated",
     }
+
+
 class AuthConfigTest(NamedTuple):
     secret_keys: List[str]
     config: Union[Dict[str, Any], AuthConfigBase]

--- a/tests/rest_api/test_configurations.py
+++ b/tests/rest_api/test_configurations.py
@@ -1429,11 +1429,15 @@ def test_validation_masks_auth_secrets() -> None:
                 "type": "bearer",
                 "location": "header",
                 "token": "sensitive-secret",
-            }
+            },
         },
         "resources": ["posts"],
     }
     with pytest.raises(dlt.common.exceptions.DictValidationException) as e:
         rest_api_source(incorrect_config)
-    assert re.search("sensitive-secret", str(e.value)) is None, "sensitive-secret is printed pattern unexpectedly"
-    assert e.match(re.escape("'{'type': 'bearer', 'location': 'header', 'token': 's*****t'}'"))
+    assert (
+        re.search("sensitive-secret", str(e.value)) is None
+    ), "sensitive-secret is printed pattern unexpectedly"
+    assert e.match(
+        re.escape("'{'type': 'bearer', 'location': 'header', 'token': 's*****t'}'")
+    )

--- a/tests/rest_api/test_configurations.py
+++ b/tests/rest_api/test_configurations.py
@@ -1557,7 +1557,7 @@ def test_validation_masks_auth_secrets() -> None:
         rest_api_source(incorrect_config)
     assert (
         re.search("sensitive-secret", str(e.value)) is None
-    ), "sensitive-secret printed pattern unexpectedly"
+    ), "unexpectedly printed 'sensitive-secret'"
     assert e.match(
         re.escape("'{'type': 'bearer', 'location': 'header', 'token': 's*****t'}'")
     )

--- a/tests/rest_api/test_paginators.py
+++ b/tests/rest_api/test_paginators.py
@@ -1,4 +1,3 @@
-
 import pytest
 from sources import rest_api
 from sources.rest_api.typing import PaginatorConfig


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Tell us what you do here
fixing a bug (please link a relevant bug report)

### Short description

The masking of secrets works as follows:
1. deepcopy the configuration dict
2. take the `auth` configuration and replace all values for allowed sensitive keys with masked versions
3. validate the deep copy where sensitive values are replaced

Assumption:
Authentication objects that are not dictionaries are expected not to print their sensitive values when `__str__()` is called.

Complexity:
- The auth configuration allows both config dictionaries and specific classes. Thus, we need to do runtime type checks.
- implementing polymorphic dispatch, e.g. `auth_config.mask_secrets()` for dicts that are also callable (HttpBasicAuth, BearerTokenAuth, APIKeyAuth) requires an update in the dlt core library. See implementation here: https://github.com/dlt-hub/dlt/issues/1474

### Related Issues

- Fixes https://github.com/dlt-hub/dlt/issues/1474
