### PR TITLE
rest_api: changes incremental configuration from `transform` to `convert`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1063,13 +1063,13 @@ files = [
 
 [[package]]
 name = "dlt"
-version = "0.5.2a1"
+version = "0.5.2a2"
 description = "dlt is an open-source python-first scalable data loading library that does not require any backend to run."
 optional = false
 python-versions = "<3.13,>=3.8.1"
 files = [
-    {file = "dlt-0.5.2a1-py3-none-any.whl", hash = "sha256:755026dca845bf3a775060758ed61fc6907feb8b493774a82e2c8778bdd20ef7"},
-    {file = "dlt-0.5.2a1.tar.gz", hash = "sha256:184912b3888915cfc12931d6a2d4b131d225f58b5eb07bc25eaf96a63872c8a9"},
+    {file = "dlt-0.5.2a2-py3-none-any.whl", hash = "sha256:d634b8100485d20e24f124462c80df42f2f640b4ea141dcadb2454dff8e2699a"},
+    {file = "dlt-0.5.2a2.tar.gz", hash = "sha256:777f280794da80b2574dc59a68931bffec869b26c7d24a738ba64d0cf8b37882"},
 ]
 
 [package.dependencies]
@@ -6433,4 +6433,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.13"
-content-hash = "a554d522777de3fd04fe0cb73f3bedbd63edb4d72fa09a37dc6429ee60685458"
+content-hash = "f32cce48e50bad46deae42e7882ad4fd6f6f67329a64867c576fda6133a6c7c2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = [{include = "sources"}]
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<3.13"
-dlt = {version = "0.5.2a1", allow-prereleases = true, extras = ["redshift", "bigquery", "postgres", "duckdb"]}
+dlt = {version = "0.5.2a2", allow-prereleases = true, extras = ["redshift", "bigquery", "postgres", "duckdb"]}
 graphlib-backport = {version = "*", python = "<3.9"}
 
 [tool.poetry.group.dev.dependencies]

--- a/sources/rest_api/config_setup.py
+++ b/sources/rest_api/config_setup.py
@@ -38,7 +38,7 @@ from dlt.sources.helpers.rest_client.paginators import (
 try:
     from dlt.sources.helpers.rest_client.paginators import JSONLinkPaginator
 except ImportError:
-    from dlt.sources.helpers.rest_client.paginators import JSONResponsePaginator as JSONLinkPaginator  # type: ignore
+    from dlt.sources.helpers.rest_client.paginators import JSONResponsePaginator as JSONLinkPaginator
 
 from dlt.sources.helpers.rest_client.detector import single_entity_path
 from dlt.sources.helpers.rest_client.exceptions import IgnoreResponseException

--- a/sources/rest_api/config_setup.py
+++ b/sources/rest_api/config_setup.py
@@ -1,3 +1,4 @@
+import warnings
 from copy import copy
 from typing import (
     Type,
@@ -177,7 +178,7 @@ def setup_incremental_object(
         raise ValueError(
             f"Only a single incremental parameter is allower per endpoint. Found: {incremental_params}"
         )
-    transform: Optional[Callable[..., Any]]
+    convert: Optional[Callable[..., Any]]
     for param_name, param_config in request_params.items():
         if isinstance(param_config, dlt.sources.incremental):
             if param_config.end_value is not None:
@@ -190,18 +191,19 @@ def setup_incremental_object(
                 raise ValueError(
                     f"Only start_param and initial_value are allowed in the configuration of param: {param_name}. To set end_value too use the incremental configuration at the resource level. See https://dlthub.com/docs/dlt-ecosystem/verified-sources/rest_api#incremental-loading"
                 )
-            transform = param_config.get("transform", None)
-            config = exclude_keys(param_config, {"type", "transform"})
+            convert = parse_convert_or_deprecated_transform(param_config)
+
+            config = exclude_keys(param_config, {"type", "convert", "transform"})
             # TODO: implement param type to bind incremental to
             return (
                 dlt.sources.incremental(**config),
                 IncrementalParam(start=param_name, end=None),
-                transform,
+                convert,
             )
     if incremental_config:
-        transform = incremental_config.get("transform", None)
+        convert = parse_convert_or_deprecated_transform(incremental_config)
         config = exclude_keys(
-            incremental_config, {"start_param", "end_param", "transform"}
+            incremental_config, {"start_param", "end_param", "convert", "transform"}
         )
         return (
             dlt.sources.incremental(**config),
@@ -209,10 +211,26 @@ def setup_incremental_object(
                 start=incremental_config["start_param"],
                 end=incremental_config.get("end_param"),
             ),
-            transform,
+            convert,
         )
 
     return None, None, None
+
+
+def parse_convert_or_deprecated_transform(
+    config: Union[IncrementalConfig, Dict[str, Any]]
+) -> Optional[Callable[..., Any]]:
+    convert = config.get("convert", None)
+    deprecated_transform = config.get("transform", None)
+    if deprecated_transform:
+        warnings.warn(
+            "The key `transform` is deprecated in the incremental configuration and it will be removed. "
+            "Use `convert` instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        convert = deprecated_transform
+    return convert
 
 
 def make_parent_key_name(resource_name: str, field_name: str) -> str:

--- a/sources/rest_api/typing.py
+++ b/sources/rest_api/typing.py
@@ -38,7 +38,7 @@ from dlt.sources.helpers.rest_client.paginators import (
 try:
     from dlt.sources.helpers.rest_client.paginators import JSONLinkPaginator
 except ImportError:
-    from dlt.sources.helpers.rest_client.paginators import JSONResponsePaginator as JSONLinkPaginator  # type: ignore
+    from dlt.sources.helpers.rest_client.paginators import JSONResponsePaginator as JSONLinkPaginator
 
 from dlt.sources.helpers.rest_client.auth import (
     AuthConfigBase,

--- a/sources/rest_api/typing.py
+++ b/sources/rest_api/typing.py
@@ -182,7 +182,7 @@ class IncrementalArgs(TypedDict, total=False):
     primary_key: Optional[TTableHintTemplate[TColumnNames]]
     end_value: Optional[str]
     row_order: Optional[TSortOrder]
-    transform: Optional[Callable[..., Any]]
+    convert: Optional[Callable[..., Any]]
 
 
 class IncrementalConfig(IncrementalArgs, total=False):

--- a/tests/rest_api/test_rest_api_source_offline.py
+++ b/tests/rest_api/test_rest_api_source_offline.py
@@ -433,7 +433,7 @@ def test_response_actions_called_in_order(mock_api_server, mocker):
     assert all(record["custom_field"] == "foobar" for record in data)
 
 
-def test_posts_with_inremental_date_transformation(mock_api_server) -> None:
+def test_posts_with_inremental_date_conversion(mock_api_server) -> None:
     start_time = pendulum.from_timestamp(1)
     one_day_later = start_time.add(days=1)
     config: RESTAPIConfig = {
@@ -449,7 +449,7 @@ def test_posts_with_inremental_date_transformation(mock_api_server) -> None:
                         "cursor_path": "updated_at",
                         "initial_value": str(start_time.int_timestamp),
                         "end_value": str(one_day_later.int_timestamp),
-                        "transform": lambda epoch: pendulum.from_timestamp(
+                        "convert": lambda epoch: pendulum.from_timestamp(
                             int(epoch)
                         ).to_date_string(),
                     },


### PR DESCRIPTION


<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Tell us what you do here
<!--
Pick the relevant item or items and remove the rest: 
-->

- improving, documenting, or customizing an existing source (please link an issue or describe below)

### Short description

This PR:
1. renames the incremental config key `transform` to `convert`
2. deprecates the old `transform` so that it still works but issues a warning

### Related Issues

- Resolves #544 

### Additional Context

<!--
Please ensure that
    - you have read the [Contributing Guide](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
