### PR TITLE
SQL database: included_columns option

### DIFF
--- a/sources/sql_database/__init__.py
+++ b/sources/sql_database/__init__.py
@@ -182,7 +182,7 @@ def sql_table(
         table, metadata, autoload_with=None if defer_table_reflect else engine
     )
     if not defer_table_reflect:
-        default_table_adapter(table_obj)
+        default_table_adapter(table_obj, included_columns)
         if table_adapter_callback:
             table_adapter_callback(table_obj)
 
@@ -190,9 +190,7 @@ def sql_table(
         table_rows,
         name=table_obj.name,
         primary_key=get_primary_key(table_obj),
-        columns=table_to_columns(
-            table_obj, reflection_level, type_adapter_callback, included_columns
-        ),
+        columns=table_to_columns(table_obj, reflection_level, type_adapter_callback),
     )(
         engine,
         table_obj,

--- a/sources/sql_database/__init__.py
+++ b/sources/sql_database/__init__.py
@@ -111,7 +111,7 @@ def sql_database(
             name=table.name,
             primary_key=get_primary_key(table),
             spec=SqlDatabaseTableConfiguration,
-            columns=table_to_columns(table, reflection_level, type_adapter_callback),
+            # columns hint will be set at runtime, after included_columns setting has been resolved
         )(
             engine,
             table,
@@ -142,6 +142,7 @@ def sql_table(
     table_adapter_callback: Callable[[Table], None] = None,
     backend_kwargs: Dict[str, Any] = None,
     type_adapter_callback: Optional[TTypeAdapter] = None,
+    included_columns: Optional[List[str]] = None,
 ) -> DltResource:
     """
     A dlt resource which loads data from an SQL database table using SQLAlchemy.
@@ -170,6 +171,7 @@ def sql_table(
         backend_kwargs (**kwargs): kwargs passed to table backend ie. "conn" is used to pass specialized connection string to connectorx.
         type_adapter_callback(Optional[Callable]): Callable to override type inference when reflecting columns.
             Argument is a single sqlalchemy data type (`TypeEngine` instance) and it should return another sqlalchemy data type, or `None` (type will be inferred from data)
+        included_columns (Optional[List[str]): List of column names to select from the table. If not provided, all columns are loaded.
 
     Returns:
         DltResource: The dlt resource for loading data from the SQL database table.
@@ -197,7 +199,9 @@ def sql_table(
         table_rows,
         name=table_obj.name,
         primary_key=get_primary_key(table_obj),
-        columns=table_to_columns(table_obj, reflection_level, type_adapter_callback),
+        columns=table_to_columns(
+            table_obj, reflection_level, type_adapter_callback, included_columns
+        ),
     )(
         engine,
         table_obj,
@@ -209,4 +213,5 @@ def sql_table(
         table_adapter_callback=table_adapter_callback,
         backend_kwargs=backend_kwargs,
         type_adapter_callback=type_adapter_callback,
+        included_columns=included_columns,
     )

--- a/sources/sql_database/schema_types.py
+++ b/sources/sql_database/schema_types.py
@@ -139,6 +139,7 @@ def table_to_columns(
     table: Table,
     reflection_level: ReflectionLevel = "full",
     type_conversion_fallback: Optional[TTypeAdapter] = None,
+    included_columns: Optional[List[str]] = None,
 ) -> TTableSchemaColumns:
     """Convert an sqlalchemy table to a dlt table schema."""
     return {
@@ -146,6 +147,7 @@ def table_to_columns(
         for col in (
             sqla_col_to_column_schema(c, reflection_level, type_conversion_fallback)
             for c in table.columns
+            if included_columns is None or c.name in included_columns
         )
         if col is not None
     }

--- a/sources/sql_database_pipeline.py
+++ b/sources/sql_database_pipeline.py
@@ -1,6 +1,7 @@
 import sqlalchemy as sa
 import humanize
 from typing import Any
+import os
 
 import dlt
 from dlt.common import pendulum
@@ -323,6 +324,29 @@ def use_type_adapter() -> None:
         type_adapter_callback=type_adapter,
         reflection_level="full_with_precision",
     ).with_resources("table_with_array_column")
+
+    info = pipeline.run(sql_alchemy_source)
+    print(info)
+
+
+def specify_columns_to_load() -> None:
+    """Run the SQL database source with a subset of table columns loaded"""
+    pipeline = dlt.pipeline(
+        pipeline_name="dummy",
+        destination="postgres",
+        dataset_name="dummy",
+    )
+
+    # Columns can be specified per table in env var (json array) or in `.dlt/config.toml`
+    os.environ["SOURCES__SQL_DATABASE__FAMILY__INCLUDED_COLUMNS"] = (
+        '["rfam_acc", "description"]'
+    )
+
+    sql_alchemy_source = sql_database(
+        "mysql+pymysql://rfamro@mysql-rfam-public.ebi.ac.uk:4497/Rfam?&binary_prefix=true",
+        backend="pyarrow",
+        reflection_level="full_with_precision",
+    ).with_resources("family", "genome")
 
     info = pipeline.run(sql_alchemy_source)
     print(info)

--- a/tests/sql_database/test_helpers.py
+++ b/tests/sql_database/test_helpers.py
@@ -2,7 +2,6 @@ import pytest
 
 import dlt
 from dlt.common.typing import TDataItem
-import sqlalchemy as sa
 
 from sources.sql_database.helpers import TableLoader, TableBackend
 from sources.sql_database.schema_types import table_to_columns
@@ -50,7 +49,7 @@ def test_make_query_incremental_max(
 
     query = loader.make_query()
     expected = (
-        sa.select(*table.c)
+        table.select()
         .order_by(table.c.created_at.asc())
         .where(table.c.created_at >= MockIncremental.last_value)
     )
@@ -80,7 +79,7 @@ def test_make_query_incremental_min(
 
     query = loader.make_query()
     expected = (
-        sa.select(*table.c)
+        table.select()
         .order_by(table.c.created_at.asc())  # `min` func swaps order
         .where(table.c.created_at <= MockIncremental.last_value)
     )
@@ -112,7 +111,7 @@ def test_make_query_incremental_end_value(
 
     query = loader.make_query()
     expected = (
-        sa.select(*table.c)
+        table.select()
         .where(table.c.created_at <= MockIncremental.last_value)
         .where(table.c.created_at > MockIncremental.end_value)
     )
@@ -141,7 +140,7 @@ def test_make_query_incremental_any_fun(
     )
 
     query = loader.make_query()
-    expected = sa.select(*table.c)
+    expected = table.select()
 
     assert query.compare(expected)
 

--- a/tests/sql_database/test_helpers.py
+++ b/tests/sql_database/test_helpers.py
@@ -2,6 +2,7 @@ import pytest
 
 import dlt
 from dlt.common.typing import TDataItem
+import sqlalchemy as sa
 
 from sources.sql_database.helpers import TableLoader, TableBackend
 from sources.sql_database.schema_types import table_to_columns
@@ -49,7 +50,7 @@ def test_make_query_incremental_max(
 
     query = loader.make_query()
     expected = (
-        table.select()
+        sa.select(*table.c)
         .order_by(table.c.created_at.asc())
         .where(table.c.created_at >= MockIncremental.last_value)
     )
@@ -79,7 +80,7 @@ def test_make_query_incremental_min(
 
     query = loader.make_query()
     expected = (
-        table.select()
+        sa.select(*table.c)
         .order_by(table.c.created_at.asc())  # `min` func swaps order
         .where(table.c.created_at <= MockIncremental.last_value)
     )
@@ -111,7 +112,7 @@ def test_make_query_incremental_end_value(
 
     query = loader.make_query()
     expected = (
-        table.select()
+        sa.select(*table.c)
         .where(table.c.created_at <= MockIncremental.last_value)
         .where(table.c.created_at > MockIncremental.end_value)
     )
@@ -140,7 +141,7 @@ def test_make_query_incremental_any_fun(
     )
 
     query = loader.make_query()
-    expected = table.select()
+    expected = sa.select(*table.c)
 
     assert query.compare(expected)
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Tell us what you do here
- improving, documenting, or customizing an existing source (please link an issue or describe below)

### Short description

This adds `included_columns` option for sql database ( I would have named it `columns` but that was conflicting with the `$COLUMNS` shell variable in config resolution)   

Can be set with argument or config in in the standalone resource, and with config in the database source, e.g.:

```toml
[sources.sql_database.campaign]
included_columns = ["id", "name", "created_at", "updated_at"]
```

### Related Issues
One part of https://github.com/dlt-hub/verified-sources/issues/531#issuecomment-2267646842  
The query editing callback I would do in another PR
