### PR TITLE
SQL database: query adapter callback

### DIFF
--- a/sources/sql_database/__init__.py
+++ b/sources/sql_database/__init__.py
@@ -18,6 +18,7 @@ from .helpers import (
     SqlDatabaseTableConfiguration,
     SqlTableResourceConfiguration,
     _detect_precision_hints_deprecated,
+    TQueryAdapter,
 )
 from .schema_types import (
     default_table_adapter,
@@ -43,6 +44,7 @@ def sql_database(
     backend_kwargs: Dict[str, Any] = None,
     include_views: bool = False,
     type_adapter_callback: Optional[TTypeAdapter] = None,
+    query_adapter_callback: Optional[TQueryAdapter] = None,
 ) -> Iterable[DltResource]:
     """
     A dlt source which loads data from an SQL database using SQLAlchemy.
@@ -71,8 +73,10 @@ def sql_database(
         include_views (bool): Reflect views as well as tables. Note view names included in `table_names` are always included regardless of this setting.
         type_adapter_callback(Optional[Callable]): Callable to override type inference when reflecting columns.
             Argument is a single sqlalchemy data type (`TypeEngine` instance) and it should return another sqlalchemy data type, or `None` (type will be inferred from data)
-    Returns:
+        query_adapter_callback(Optional[Callable[Select, Table], Select]): Callable to override the SELECT query used to fetch data from the table.
+            The callback receives the sqlalchemy `Select` and corresponding `Table` objects and should return the modified `Select`.
 
+    Returns:
         Iterable[DltResource]: A list of DLT resources for each table to be loaded.
     """
     # detect precision hints is deprecated
@@ -113,6 +117,7 @@ def sql_database(
             table_adapter_callback=table_adapter_callback,
             backend_kwargs=backend_kwargs,
             type_adapter_callback=type_adapter_callback,
+            query_adapter_callback=query_adapter_callback,
         )
 
 
@@ -134,6 +139,7 @@ def sql_table(
     backend_kwargs: Dict[str, Any] = None,
     type_adapter_callback: Optional[TTypeAdapter] = None,
     included_columns: Optional[List[str]] = None,
+    query_adapter_callback: Optional[TQueryAdapter] = None,
 ) -> DltResource:
     """
     A dlt resource which loads data from an SQL database table using SQLAlchemy.
@@ -163,6 +169,8 @@ def sql_table(
         type_adapter_callback(Optional[Callable]): Callable to override type inference when reflecting columns.
             Argument is a single sqlalchemy data type (`TypeEngine` instance) and it should return another sqlalchemy data type, or `None` (type will be inferred from data)
         included_columns (Optional[List[str]): List of column names to select from the table. If not provided, all columns are loaded.
+        query_adapter_callback(Optional[Callable[Select, Table], Select]): Callable to override the SELECT query used to fetch data from the table.
+            The callback receives the sqlalchemy `Select` and corresponding `Table` objects and should return the modified `Select`.
 
     Returns:
         DltResource: The dlt resource for loading data from the SQL database table.
@@ -203,4 +211,5 @@ def sql_table(
         backend_kwargs=backend_kwargs,
         type_adapter_callback=type_adapter_callback,
         included_columns=included_columns,
+        query_adapter_callback=query_adapter_callback,
     )


### PR DESCRIPTION
~~Note: this includes the commits of https://github.com/dlt-hub/verified-sources/pull/550 , will rebase after that is merged.~~

<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Tell us what you do here
- improving, documenting, or customizing an existing source (please link an issue or describe below)
### Short description
Implements `query_adapter_callback` argument for sql database. Can be used to modify or completely replace the generated sqlalchemy query, e.g.:

```python
    def query_adapter_callback(query, table):
        if table.name == "chat_channel":
            # Only select active channels
            return query.where(table.c.active.is_(True))
        # Use the original query for other tables
        return query
```



<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues
Second part of https://github.com/dlt-hub/verified-sources/issues/531#issuecomment-2267646842

### Additional Context

<!--
Please ensure that
    - you have read the [Contributing Guide](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
