### PR TITLE
add option for including ticket comments from zendesk

### DIFF
--- a/sources/zendesk_pipeline.py
+++ b/sources/zendesk_pipeline.py
@@ -49,6 +49,22 @@ def load_support_with_pivoting() -> Any:
     return info
 
 
+def load_support_with_ticket_comments() -> Any:
+    """
+    Loads Zendesk Support data with ticket comments included. 
+    Simply done by setting the include_ticket_comments to true.
+    Loads only the base tables.
+    """
+    pipeline = dlt.pipeline(
+        pipeline_name="zendesk_support_pivoting",
+        destination="postgres",
+        dev_mode=False,
+    )
+    data = zendesk_support(load_all=False, include_ticket_comments=True)
+    info = pipeline.run(data=data)
+    return info
+
+
 def incremental_load_all_start_date() -> Any:
     """
     Implements incremental load when possible to Support, Chat and Talk Endpoints. The default behaviour gets data since the last load time saved in dlt state or


### PR DESCRIPTION

Adding a flag for whether ticket comments should be included in the sync from zendesk

### Tell us what you do here
I've added a flag for whether the sync from zendesk should include the actual content of the comments. Per the zendesk [docs](https://developer.zendesk.com/api-reference/ticketing/ticket-management/incremental_exports/#incremental-ticket-event-export), this is done with a sideload by adding an `include` parameter

Pick the relevant item or items and remove the rest: 
- improving, documenting, or customizing an existing source (please link an issue or describe below)
issue [here](https://github.com/dlt-hub/verified-sources/issues/579)

### Related Issues
- Resolves 579 issue [here](https://github.com/dlt-hub/verified-sources/issues/579)
