### PR TITLE
mongodb: Allow projection and mongoarrow schema

### DIFF
--- a/sources/hubspot/helpers.py
+++ b/sources/hubspot/helpers.py
@@ -49,7 +49,7 @@ def extract_association_data(
     _obj: Dict[str, Any],
     data: Dict[str, Any],
     association: str,
-    headers: Dict[str, Any]
+    headers: Dict[str, Any],
 ) -> List[Dict[str, Any]]:
     values = []
 

--- a/sources/mongodb/__init__.py
+++ b/sources/mongodb/__init__.py
@@ -1,6 +1,6 @@
 """Source that loads collections form any a mongo database, supports incremental loads."""
 
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Union, Mapping
 
 import dlt
 from dlt.common.data_writers import TDataItemFormat
@@ -74,6 +74,7 @@ def mongodb(
             parallel=parallel,
             limit=limit,
             filter_=filter_ or {},
+            projection=None,
         )
 
 
@@ -93,6 +94,7 @@ def mongodb_collection(
     chunk_size: Optional[int] = 10000,
     data_item_format: Optional[TDataItemFormat] = "object",
     filter_: Optional[Dict[str, Any]] = None,
+    projection: Optional[Union[Mapping[str, Any], Iterable[str]]] = None,
 ) -> Any:
     """
     A DLT source which loads a collection from a mongo database using PyMongo.
@@ -112,6 +114,12 @@ def mongodb_collection(
                 object - Python objects (dicts, lists).
                 arrow - Apache Arrow tables.
         filter_ (Optional[Dict[str, Any]]): The filter to apply to the collection.
+        projection: (Optional[Union[Mapping[str, Any], Iterable[str]]]): The projection to select columns
+            when loading the collection. Supported inputs:
+                include (list) - ["year", "title"]
+                include (dict) - {"year": 1, "title": 1}
+                exclude (dict) - {"released": 0, "runtime": 0}
+            Note: Can't mix include and exclude statements '{"title": 1, "released": 0}`
 
     Returns:
         Iterable[DltResource]: A list of DLT resources for each collection to be loaded.
@@ -139,4 +147,5 @@ def mongodb_collection(
         chunk_size=chunk_size,
         data_item_format=data_item_format,
         filter_=filter_ or {},
+        projection=projection,
     )

--- a/sources/mongodb/__init__.py
+++ b/sources/mongodb/__init__.py
@@ -25,6 +25,8 @@ def mongodb(
     parallel: Optional[bool] = dlt.config.value,
     limit: Optional[int] = None,
     filter_: Optional[Dict[str, Any]] = None,
+    projection: Optional[Union[Mapping[str, Any], Iterable[str]]] = None,
+    pymongoarrow_schema: Optional[Any] = None
 ) -> Iterable[DltResource]:
     """
     A DLT source which loads data from a mongo database using PyMongo.
@@ -42,6 +44,13 @@ def mongodb(
             The maximum number of documents to load. The limit is
             applied to each requested collection separately.
         filter_ (Optional[Dict[str, Any]]): The filter to apply to the collection.
+        projection: (Optional[Union[Mapping[str, Any], Iterable[str]]]): The projection to select fields of a collection
+            when loading the collection. Supported inputs:
+                include (list) - ["year", "title"]
+                include (dict) - {"year": True, "title": True}
+                exclude (dict) - {"released": False, "runtime": False}
+            Note: Can't mix include and exclude statements '{"title": True, "released": False}`
+        pymongoarrow_schema (pymongoarrow.schema.Schema): Mapping of expected field types of a collection to convert BSON to Arrow
 
     Returns:
         Iterable[DltResource]: A list of DLT resources for each collection to be loaded.
@@ -74,7 +83,8 @@ def mongodb(
             parallel=parallel,
             limit=limit,
             filter_=filter_ or {},
-            projection=None,
+            projection=projection,
+            pymongoarrow_schema=pymongoarrow_schema,
         )
 
 
@@ -94,7 +104,8 @@ def mongodb_collection(
     chunk_size: Optional[int] = 10000,
     data_item_format: Optional[TDataItemFormat] = "object",
     filter_: Optional[Dict[str, Any]] = None,
-    projection: Optional[Union[Mapping[str, Any], Iterable[str]]] = None,
+    projection: Optional[Union[Mapping[str, Any], Iterable[str]]] = dlt.config.value,
+    pymongoarrow_schema: Optional[Any] = None
 ) -> Any:
     """
     A DLT source which loads a collection from a mongo database using PyMongo.
@@ -114,12 +125,13 @@ def mongodb_collection(
                 object - Python objects (dicts, lists).
                 arrow - Apache Arrow tables.
         filter_ (Optional[Dict[str, Any]]): The filter to apply to the collection.
-        projection: (Optional[Union[Mapping[str, Any], Iterable[str]]]): The projection to select columns
+        projection: (Optional[Union[Mapping[str, Any], Iterable[str]]]): The projection to select fields
             when loading the collection. Supported inputs:
                 include (list) - ["year", "title"]
-                include (dict) - {"year": 1, "title": 1}
-                exclude (dict) - {"released": 0, "runtime": 0}
-            Note: Can't mix include and exclude statements '{"title": 1, "released": 0}`
+                include (dict) - {"year": True, "title": True}
+                exclude (dict) - {"released": False, "runtime": False}
+            Note: Can't mix include and exclude statements '{"title": True, "released": False}`
+        pymongoarrow_schema (pymongoarrow.schema.Schema): Mapping of expected field types to convert BSON to Arrow
 
     Returns:
         Iterable[DltResource]: A list of DLT resources for each collection to be loaded.
@@ -148,4 +160,5 @@ def mongodb_collection(
         data_item_format=data_item_format,
         filter_=filter_ or {},
         projection=projection,
+        pymongoarrow_schema=pymongoarrow_schema,
     )

--- a/sources/mongodb/__init__.py
+++ b/sources/mongodb/__init__.py
@@ -26,7 +26,7 @@ def mongodb(
     limit: Optional[int] = None,
     filter_: Optional[Dict[str, Any]] = None,
     projection: Optional[Union[Mapping[str, Any], Iterable[str]]] = None,
-    pymongoarrow_schema: Optional[Any] = None
+    pymongoarrow_schema: Optional[Any] = None,
 ) -> Iterable[DltResource]:
     """
     A DLT source which loads data from a mongo database using PyMongo.
@@ -105,7 +105,7 @@ def mongodb_collection(
     data_item_format: Optional[TDataItemFormat] = "object",
     filter_: Optional[Dict[str, Any]] = None,
     projection: Optional[Union[Mapping[str, Any], Iterable[str]]] = dlt.config.value,
-    pymongoarrow_schema: Optional[Any] = None
+    pymongoarrow_schema: Optional[Any] = None,
 ) -> Any:
     """
     A DLT source which loads a collection from a mongo database using PyMongo.

--- a/tests/mongodb/test_mongodb_source.py
+++ b/tests/mongodb/test_mongodb_source.py
@@ -593,5 +593,9 @@ def test_pymongoarrow_schema(convert_to_string: bool, destination_name: str):
         dev_mode=True,
     )
 
-    info = pipeline.run(res)
+    if destination_name in ("bigquery", "postgres"):
+        res = list(res)[0]
+        res = res.drop_columns(["field7", "field8"])
+
+    info = pipeline.run(res, table_name="types_test")
     assert info.loads_ids != []

--- a/tests/mongodb/test_mongodb_source.py
+++ b/tests/mongodb/test_mongodb_source.py
@@ -422,9 +422,7 @@ def test_projection_list_inclusion(destination_name):
     expected_columns = projection + ["_id", "_dlt_id", "_dlt_load_id"]
 
     movies = mongodb_collection(
-        collection=collection_name,
-        projection=projection,
-        limit=2
+        collection=collection_name, projection=projection, limit=2
     )
     pipeline.run(movies)
     loaded_columns = pipeline.default_schema.get_table_columns(collection_name).keys()
@@ -445,9 +443,7 @@ def test_projection_dict_inclusion(destination_name):
     expected_columns = list(projection.keys()) + ["_id", "_dlt_id", "_dlt_load_id"]
 
     movies = mongodb_collection(
-        collection=collection_name,
-        projection=projection,
-        limit=2
+        collection=collection_name, projection=projection, limit=2
     )
     pipeline.run(movies)
     loaded_columns = pipeline.default_schema.get_table_columns(collection_name).keys()
@@ -465,17 +461,28 @@ def test_projection_dict_exclusion(destination_name):
     )
     collection_name = "movies"
     columns_to_exclude = [
-        "runtime", "released", "year", "plot", "fullplot", "lastupdated", "type",
-        "directors", "imdb", "cast", "countries", "genres", "tomatoes", "num_mflix_comments",
-        "rated", "awards"
+        "runtime",
+        "released",
+        "year",
+        "plot",
+        "fullplot",
+        "lastupdated",
+        "type",
+        "directors",
+        "imdb",
+        "cast",
+        "countries",
+        "genres",
+        "tomatoes",
+        "num_mflix_comments",
+        "rated",
+        "awards",
     ]
     projection = {col: 0 for col in columns_to_exclude}
     expected_columns = ["title", "poster", "_id", "_dlt_id", "_dlt_load_id"]
 
     movies = mongodb_collection(
-        collection=collection_name,
-        projection=projection,
-        limit=2
+        collection=collection_name, projection=projection, limit=2
     )
     pipeline.run(movies)
     loaded_columns = pipeline.default_schema.get_table_columns(collection_name).keys()

--- a/tests/mongodb/test_mongodb_source.py
+++ b/tests/mongodb/test_mongodb_source.py
@@ -374,7 +374,7 @@ def test_filter(destination_name):
         pipeline_name="mongodb_test",
         destination=destination_name,
         dataset_name="mongodb_test_data",
-        full_refresh=True,
+        dev_mode=True,
     )
     movies = mongodb_collection(
         collection="movies",
@@ -397,7 +397,7 @@ def test_filter_intersect(destination_name):
         pipeline_name="mongodb_test",
         destination=destination_name,
         dataset_name="mongodb_test_data",
-        full_refresh=True,
+        dev_mode=True,
     )
     movies = mongodb_collection(
         collection="movies",
@@ -415,7 +415,7 @@ def test_projection_list_inclusion(destination_name):
         pipeline_name="mongodb_test",
         destination=destination_name,
         dataset_name="mongodb_test_data",
-        full_refresh=True,
+        dev_mode=True,
     )
     collection_name = "movies"
     projection = ["title", "poster"]
@@ -436,7 +436,7 @@ def test_projection_dict_inclusion(destination_name):
         pipeline_name="mongodb_test",
         destination=destination_name,
         dataset_name="mongodb_test_data",
-        full_refresh=True,
+        dev_mode=True,
     )
     collection_name = "movies"
     projection = {"title": 1, "poster": 1}
@@ -457,7 +457,7 @@ def test_projection_dict_exclusion(destination_name):
         pipeline_name="mongodb_test",
         destination=destination_name,
         dataset_name="mongodb_test_data",
-        full_refresh=True,
+        dev_mode=True,
     )
     collection_name = "movies"
     columns_to_exclude = [
@@ -496,7 +496,7 @@ def test_projection_nested_field(destination_name):
         pipeline_name="mongodb_test",
         destination=destination_name,
         dataset_name="mongodb_test_data",
-        full_refresh=True,
+        dev_mode=True,
     )
     collection_name = "movies"
     projection = ["imdb.votes", "poster"]
@@ -526,7 +526,7 @@ def test_mongodb_without_pymongoarrow(
             pipeline_name="test_mongodb_without_pymongoarrow",
             destination=destination_name,
             dataset_name="test_mongodb_without_pymongoarrow_data",
-            full_refresh=True,
+            dev_mode=True,
         )
 
         comments = mongodb_collection(


### PR DESCRIPTION
## Tell us what you do here
- improving, documenting, or customizing an existing source (#577)

## Short description

This implements two sets of features:
- Improve default behavior for `objectId` type and add `pymongoarrow_schema` for a user-facing type-casting API for `mongodb -> pyarrow`
- Add `projection` kwarg: allows to select the fields to include/exclude when pulling the data from MongoDB. This reduces egress volume and helps with regulatory compliance (e.g., don't pull sensitive information)

## Notes
- Using `pymongoarrow_schema` can intersect with the column selection in `projection`. The `pymongoarrow_schema` overrides the projection kwarg.
- The `pymongoarrow_schema` will "fail silently" if you cast to an invalid type (e.g., `ObjectId` to `int`): https://github.com/mongodb-labs/mongo-arrow/issues/246
- `ObjectId` is represented as a `binary[12]` type in Arrow using `pymongoarrow`. There's no vectorized operation to convert this to a string since the buffer contains ASCII characters.
- Invalid types in `pymongoarrow_schema` will make `pipeline.run()` fail with an hard to trace error `Out of buffer` coming from arrow (e.g., `_id: pyarrow.string()`.
  ```python
  E           dlt.pipeline.exceptions.PipelineStepFailed: Pipeline execution failed at stage load when processing package 1736799421.5290868 with exception:
  E           
  E           <class 'dlt.load.exceptions.LoadClientJobRetry'>
  E           Job for movies.e27d2e9dab.parquet had 5 retries which a multiple of 5. Exiting retry loop. You can still rerun the load package to retry this job. Last failure message was Out of buffer
  ```
- `pymongoarrow.schema.Schema` validates that its type annotations are valid a `__init__()`

## Future work
- As `pymongoarrow` is updated, we can raise failed type casting.
- Vectorize the operation to cast `ObjectId` to string. 
- If we can't vectorize type casting from `ObjectId` to `string`, then we can't efficiently handle nested arrays and structs without looping through each


## Open questions

1. ~~`projection` was added to `mongodb_collection` resource. Should it be added to `mongodb` source? Then, the projection would be applied to all the generated resources.~~
2. ~~`projection` + incremental loading: should we raise an exception if the `primary_key` is excluded? or force its inclusion and log a warning (current implementation)?.~~
3. ~~`pymongoarrow_schema` is applied at extract-time and it's hard to surface schema issues to the user. How much validation needs to happen within the dlt source code vs. user code?~~
4. ~~Should we upgrade from `pymongoarrow == 1.4.0` to `== 1.6.0` given their better type support?~~

### Related Issues

- Fixes #577 
