### PR TITLE
fix/extraction of all data from associations in hubspot

### DIFF
--- a/sources/hubspot/helpers.py
+++ b/sources/hubspot/helpers.py
@@ -45,7 +45,12 @@ def pagination(
         return None
 
 
-def extract_association_data(_obj, data, association, headers):
+def extract_association_data(
+    _obj: Dict[str, Any],
+    data: Dict[str, Any],
+    association: str,
+    headers: Dict[str, Any]
+) -> List[Dict[str, Any]]:
     values = []
 
     while data is not None:

--- a/sources/hubspot/helpers.py
+++ b/sources/hubspot/helpers.py
@@ -45,6 +45,21 @@ def pagination(
         return None
 
 
+def extract_association_data(_obj, data, association, headers):
+    values = []
+
+    while data is not None:
+        for r in data["results"]:
+            values.append(
+                {
+                    "value": _obj["hs_object_id"],
+                    f"{association}_id": r["id"],
+                }
+            )
+        data = pagination(data, headers)
+    return values
+
+
 def extract_property_history(objects: List[Dict[str, Any]]) -> Iterator[Dict[str, Any]]:
     for item in objects:
         history = item.get("propertiesWithHistory")
@@ -156,13 +171,11 @@ def fetch_data(
                     _obj["id"] = _result["id"]
                 if "associations" in _result:
                     for association in _result["associations"]:
-                        __values = [
-                            {
-                                "value": _obj["hs_object_id"],
-                                f"{association}_id": __r["id"],
-                            }
-                            for __r in _result["associations"][association]["results"]
-                        ]
+                        __data = _result["associations"][association]
+
+                        __values = extract_association_data(
+                            _obj, __data, association, headers
+                        )
 
                         # remove duplicates from list of dicts
                         __values = [


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Tell us what you do here

<!--
Pick the relevant item or items and remove the rest: 
-->
- fixing a bug https://github.com/dlt-hub/verified-sources/issues/593

### Short description

Updates the logic for handling the "associations" field in the "results" section of the API response. Previously, only data from the first page was read. With this update, the implementation now follows pagination links to extract data from all pages.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

### Additional Context

<!--
Please ensure that
    - you have read the [Contributing Guide](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
