### PR TITLE
update pipedrive source with projects and tasks

### DIFF
--- a/sources/pipedrive/__init__.py
+++ b/sources/pipedrive/__init__.py
@@ -9,7 +9,7 @@ Api changelog: https://developers.pipedrive.com/changelog
 To get an api key: https://pipedrive.readme.io/docs/how-to-find-the-api-token
 """
 
-from typing import Any, Dict, Iterator, List, Optional, Union, Iterable, Iterator, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Union, Iterator
 
 import dlt
 
@@ -53,6 +53,8 @@ def pipedrive_source(
         stages
         users
         leads
+        projects
+        tasks
 
     For custom fields rename the `custom_fields_mapping` resource must be selected or loaded before other resources.
 

--- a/sources/pipedrive/helpers/__init__.py
+++ b/sources/pipedrive/helpers/__init__.py
@@ -1,7 +1,6 @@
 """Pipedrive source helpers"""
 
-from dlt.common import pendulum
-from typing import Any, Iterable, Tuple, Dict, List, cast
+from typing import Any, Iterable, Tuple, Dict, List
 from itertools import groupby
 
 

--- a/sources/pipedrive/helpers/custom_fields_munger.py
+++ b/sources/pipedrive/helpers/custom_fields_munger.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Iterable, Iterator, TypedDict, Optional
+from typing import Any, Dict, TypedDict, Optional
 
 import dlt
 

--- a/sources/pipedrive/helpers/pages.py
+++ b/sources/pipedrive/helpers/pages.py
@@ -1,12 +1,10 @@
-from itertools import chain, groupby
+from itertools import chain
 from typing import (
     Any,
     Dict,
     Iterable,
     Iterator,
     List,
-    Optional,
-    Sequence,
     TypeVar,
     Union,
 )

--- a/sources/pipedrive/settings.py
+++ b/sources/pipedrive/settings.py
@@ -22,6 +22,8 @@ RECENTS_ENTITIES = {
     "organization": "organizations",
     "pipeline": "pipelines",
     "product": "products",
+    "project": "projects",
     "stage": "stages",
+    "task": "tasks",
     "user": "users",
 }


### PR DESCRIPTION
Pipedrive source should have `projects` and `tasks`
https://developers.pipedrive.com/docs/api/v1/Projects
https://developers.pipedrive.com/docs/api/v1/Tasks

The recents documentation doesn't make mention of these objects because it's an addon:
https://support.pipedrive.com/en/article/projects-by-pipedrive


VSCode also did removals of all unused imports to prevent lint complaints