### PR TITLE
fix: tests import exception from correct location

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
 ]
 
 [dependency-groups]
-dltpure = ["dlt>=1.7.0"]
+dltpure = ["dlt>=1.10.0"]
 pytest = [
     "pytest>=7.2.0,<8",
     "pytest-mock>=3.12.0,<4",

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -26,7 +26,7 @@ from dlt.common.storages import FileStorage
 from dlt.common.schema.typing import TTableSchema
 from dlt.common.utils import set_working_dir
 
-from dlt.pipeline.exceptions import SqlClientNotAvailable
+from dlt.common.destination.exceptions import SqlClientNotAvailable
 
 TEST_STORAGE_ROOT = "_storage"
 


### PR DESCRIPTION
tests did no longer run because they were trying to import this exception from a wrong location.
after moving it, most passed except the workflow `tests dlt init compatibility`.

with [refactors iceberg and duckdb cache support](https://github.com/dlt-hub/dlt/pull/2430/files#top) 
the exception imported in the utils file moved.
most workflows worked correctly, except the one in `init.yml` which didn't do make dev but only installed `dltpure`-dep-group 
```
[dependency-groups]
dltpure = ["dlt>=1.7.0"]
```
I dont understand why this didnt pick up the latest then, but apparrenlty it didnt. changing it to 1.10. works though


