### PR TITLE
fix(inbox): RFC 2822 dates parsing

### DIFF
--- a/sources/inbox/helpers.py
+++ b/sources/inbox/helpers.py
@@ -3,6 +3,7 @@ import imaplib
 import hashlib
 from email.message import Message
 from email.header import decode_header, make_header
+from email.utils import parsedate_to_datetime
 from time import mktime
 from typing import Any, Dict, Iterator, Optional, Sequence, Tuple
 
@@ -87,7 +88,9 @@ def extract_email_info(msg: Message, include_body: bool = False) -> Dict[str, An
         Dict[str, Any]: The email information.
     """
     email_data = dict(msg)
-    email_data["Date"] = pendulum.parse(msg["Date"], strict=False)
+    dt = parsedate_to_datetime(msg["Date"])
+    dt_pendulum = pendulum.instance(dt)
+    email_data["Date"] = dt_pendulum
     email_data["content_type"] = msg.get_content_type()
     if include_body:
         email_data["body"] = get_email_body(msg)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Tell us what you do here
<!--
Pick the relevant item or items and remove the rest: 
-->
- implementing verified source (please link a relevant issue labeled as `verified source`)
- fixing a bug (please link a relevant bug report)
- improving, documenting, or customizing an existing source (please link an issue or describe below)
- anything else (please link an issue or describe below)

### Short description

`Wed, 12 Jan 2022 13:08:52 GMT` is a valid RFC 2822 date, however pendulum runs into problems with it, due to the `GMT` only portion:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/joscha/dev/dagster-gmail-extractor/.devenv/state/venv/lib/python3.12/site-packages/pendulum/parser.py", line 36, in parse
    return _parse(text, **options)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/joscha/dev/dagster-gmail-extractor/.devenv/state/venv/lib/python3.12/site-packages/pendulum/parser.py", line 54, in _parse
    return pendulum.datetime(
           ^^^^^^^^^^^^^^^^^^
  File "/Users/joscha/dev/dagster-gmail-extractor/.devenv/state/venv/lib/python3.12/site-packages/pendulum/__init__.py", line 140, in datetime
    return DateTime.create(
           ^^^^^^^^^^^^^^^^
  File "/Users/joscha/dev/dagster-gmail-extractor/.devenv/state/venv/lib/python3.12/site-packages/pendulum/datetime.py", line 103, in create
    tz = pendulum._safe_timezone(tz)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/joscha/dev/dagster-gmail-extractor/.devenv/state/venv/lib/python3.12/site-packages/pendulum/__init__.py", line 109, in _safe_timezone
    elif obj.tzname(None) == "UTC":
         ^^^^^^^^^^^^^^^^
  File "/Users/joscha/dev/dagster-gmail-extractor/.devenv/state/venv/lib/python3.12/site-packages/dateutil/tz/tz.py", line 238, in tzname
    return self._tznames[self._isdst(dt)]
                         ^^^^^^^^^^^^^^^
  File "/Users/joscha/dev/dagster-gmail-extractor/.devenv/state/venv/lib/python3.12/site-packages/dateutil/tz/tz.py", line 291, in _isdst
    dstval = self._naive_is_dst(dt)
             ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/joscha/dev/dagster-gmail-extractor/.devenv/state/venv/lib/python3.12/site-packages/dateutil/tz/tz.py", line 259, in _naive_is_dst
    timestamp = _datetime_to_timestamp(dt)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/joscha/dev/dagster-gmail-extractor/.devenv/state/venv/lib/python3.12/site-packages/dateutil/tz/tz.py", line 1814, in _datetime_to_timestamp
    return (dt.replace(tzinfo=None) - EPOCH).total_seconds()
            ^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'replace'
```

The fix is to use `email.utils.parsedate_to_datetime()` to parse RFC 2822-style email date headers. It’s designed for exactly this case. We then upgrade the object to a pendulum instance after.