### PR TITLE
docs(inbox): remove mention of unused dependencies

### DIFF
--- a/sources/inbox/README.md
+++ b/sources/inbox/README.md
@@ -63,16 +63,6 @@ the
    pip install -r requirements.txt
    ```
 
-   Prerequisites for fetching messages differ by provider.
-
-    - For Gmail:
-
-      `pip install google-api-python-client>=2.86.0`
-
-      `pip install google-auth-oauthlib>=1.0.0`
-
-      `pip install google-auth-httplib2>=0.1.0`
-
     - For pdf parsing:
 
       `pip install PyPDF2`


### PR DESCRIPTION
The current version of the `inbox` source seems to rely solely on IMAP, the native GMail API is not used anywhere (anymore - can't actualyl find a commit or PR to remove it?) as far as I can tell.