### PR TITLE
Adjustable time dimension for google_analytics source

### DIFF
--- a/sources/google_analytics/helpers/__init__.py
+++ b/sources/google_analytics/helpers/__init__.py
@@ -4,7 +4,6 @@ from typing import Iterator, List
 from pendulum.datetime import DateTime
 
 import dlt
-from apiclient.discovery import Resource
 from dlt.common import logger, pendulum
 from dlt.common.typing import TDataItem
 
@@ -14,10 +13,11 @@ from google.analytics.data_v1beta.types import (
     Dimension,
     Metric,
 )
+from google.analytics.data_v1beta import BetaAnalyticsDataClient
 
 
 def basic_report(
-    client: Resource,
+    client: BetaAnalyticsDataClient,
     rows_per_page: int,
     dimensions: List[str],
     metrics: List[str],

--- a/sources/google_analytics/helpers/data_processing.py
+++ b/sources/google_analytics/helpers/data_processing.py
@@ -48,7 +48,6 @@ def to_dict(item: Any) -> Iterator[TDataItem]:
             including_default_value_fields=False,
         )
     )
-    print(item)
     yield item
 
 
@@ -177,5 +176,14 @@ def _resolve_dimension_value(dimension_name: str, dimension_value: str) -> Any:
         return pendulum.from_format(dimension_value, "YYYYMMDDHH", tz="UTC")
     elif dimension_name == "dateHourMinute":
         return pendulum.from_format(dimension_value, "YYYYMMDDHHmm", tz="UTC")
+    elif dimension_name == "yearMonth":
+        return pendulum.from_format(dimension_value, "YYYYMM", tz="UTC")
+    elif dimension_name == "isoYearIsoWeek":
+        # GA4 returns isoYearIsoWeek in format "202401"
+        year = int(dimension_value[:4])
+        week = int(dimension_value[4:])
+        return pendulum.parse(f"{year}-W{week:02d}", strict=False, tz="UTC")
+    elif dimension_name == "year":
+        return pendulum.from_format(dimension_value, "YYYY", tz="UTC")
     else:
         return dimension_value


### PR DESCRIPTION
### Description
This PR enables time dimension options for the google_analytics source. Previously, the time dimension was always set to date.

Incremental test was failing due to `pendulum.test` being deprecated. This is now replaced with a forced end date in incremental column.

### Related Issues

- Fixes #626 

