### PR TITLE
Fix Google Sheets source to not dropping columns if 1st value is null

### DIFF
--- a/sources/google_sheets/helpers/api_calls.py
+++ b/sources/google_sheets/helpers/api_calls.py
@@ -105,7 +105,7 @@ def get_known_range_names(
 
 @retry_deco
 def get_data_for_ranges(
-    service: Resource, spreadsheet_id: str, range_names: List[str]
+    service: Resource, spreadsheet_id: str, range_names: List[str], metadata_scan_rows: int = 1
 ) -> List[Tuple[str, ParsedRange, ParsedRange, List[List[Any]]]]:
     """
     Calls Google Sheets API to get data in a batch. This is the most efficient way to get data for multiple ranges inside a spreadsheet.
@@ -114,6 +114,7 @@ def get_data_for_ranges(
         service (Resource): Object to make API calls to Google Sheets.
         spreadsheet_id (str): The ID of the spreadsheet.
         range_names (List[str]): List of range names.
+        metadata_scan_rows (int, optional): Number of data rows to use for metadata detection. Defaults to 1.
 
     Returns:
         List[DictStrAny]: A list of ranges with data in the same order as `range_names`
@@ -140,8 +141,7 @@ def get_data_for_ranges(
         values: List[List[Any]] = range_.get("values", None)
         if values:
             parsed_range, values = trim_range_top_left(parsed_range, values)
-        # create a new range to get first two rows
-        meta_range = parsed_range._replace(end_row=parsed_range.start_row + 1)
-        # print(f"{name}:{parsed_range}:{meta_range}")
+        # create a new range to get header + metadata_scan_rows for metadata detection
+        meta_range = parsed_range._replace(end_row=parsed_range.start_row + metadata_scan_rows)
         rv.append((name, parsed_range, meta_range, values))
     return rv

--- a/sources/google_sheets/helpers/data_processing.py
+++ b/sources/google_sheets/helpers/data_processing.py
@@ -181,7 +181,7 @@ def get_data_types(data_row_metadata: List[DictStrAny]) -> List[TDataType]:
     Determines if each column in the first line of a range contains datetime objects.
 
     Args:
-        data_row_metadata (List[DictStrAny]): Metadata of the first row of data
+        data_row_metadata (List[DictStrAny]): Metadata of a row of data
 
     Returns:
         List[TDataType]: "timestamp" or "data" indicating the date/time type for a column, otherwise None
@@ -202,6 +202,38 @@ def get_data_types(data_row_metadata: List[DictStrAny]) -> List[TDataType]:
         return data_types
     except IndexError:
         return []
+
+
+def get_data_types_from_multiple_rows(
+    multiple_rows_metadata: List[List[DictStrAny]], 
+    expected_columns: int
+) -> List[TDataType]:
+    """
+    Determines data types by examining multiple rows of metadata. This allows to handle cases where
+    the data is sparse and the first few rows contain empty values for some columns.
+
+    Args:
+        multiple_rows_metadata (List[List[DictStrAny]]): List of metadata rows, each containing metadata for that row's columns
+        expected_columns (int): Expected number of columns (from headers)
+
+    Returns:
+        List[TDataType]: List of data types for each column, padded to expected_columns length
+    """
+    if not multiple_rows_metadata:
+        return [None] * expected_columns
+    
+    result_types: List[TDataType] = [None] * expected_columns
+    
+    for row_metadata in multiple_rows_metadata:
+        if row_metadata:
+
+          row_types = get_data_types(row_metadata)
+          
+          for idx, data_type in enumerate(row_types):
+              if idx < expected_columns and data_type is not None and result_types[idx] is None:
+                  result_types[idx] = data_type
+    
+    return result_types
 
 
 def serial_date_to_datetime(


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Tell us what you do here

I'm fixing a bug in Google Sheets that causes a column dropped if first value is null

### Short description

Fixed an issue where Google Sheets columns were being dropped when the first data row contained null/empty values in those columns. Added a new `metadata_scan_rows` parameter to the `google_spreadsheet` source that allows scanning multiple data rows for metadata detection, ensuring all columns are preserved even when early rows have sparse data.

The fix maintains full backwards compatibility by defaulting `metadata_scan_rows=1`, while allowing users to increase it for better metadata detection in spreadsheets with sparse data patterns.

Key changes:
- Added `metadata_scan_rows` parameter to `google_spreadsheet()` function
- Created `get_data_types_from_multiple_rows()` helper function
- Updated metadata processing logic to scan multiple rows and pad results to match header count
- Added comprehensive tests to verify column preservation
- Improved error handling and user guidance

### Related Issues

- Fixes #591

### Additional Context

This was a bug affecting users with spreadsheets containing empty cells in the first data row. The issue occurred because the metadata detection only examined the first row, causing columns with null values to be completely omitted from the extracted data.

The solution scans the specified number of data rows (`metadata_scan_rows`) to build a complete picture of all columns, ensuring that even columns missing from early rows are preserved in the final output. Users experiencing this issue can now simply increase `metadata_scan_rows` to a higher value (e.g., 5-10) for robust column detection.

All existing functionality remains unchanged, making this a safe upgrade for all users.
