### PR TITLE
Fix: test_ai_setup_comman references wrong branch

### DIFF
--- a/tests/test_dlt_ai.py
+++ b/tests/test_dlt_ai.py
@@ -36,13 +36,11 @@ def test_ai_setup_command(
             ai_command.ai_setup_command(
                 ide=ide,
                 repo=DEFAULT_VERIFIED_SOURCES_REPO,
-                branch="feat/continue-rules",
             )
         else:
             ai_command.ai_setup_command(
                 ide=ide,
                 location=DEFAULT_VERIFIED_SOURCES_REPO,
-                branch="feat/continue-rules",
             )
 
     base_path = Path(TEST_STORAGE_ROOT).resolve()


### PR DESCRIPTION
This PR just removes the branch specified in the test_ai_setup_command branch. We don't need specification, since it's already merged. 