### PR TITLE
Feat: Salesforce different auth methods

### DIFF
--- a/sources/salesforce/README.md
+++ b/sources/salesforce/README.md
@@ -37,7 +37,7 @@ Here, we chose BigQuery as the destination. Alternatively, you can also choose r
 
 ## Setup verified source and pipeline example
 
-To grab credentials and initialize the verified source, please refer to the [full documentation here.](https://dlthub.com/docs/dlt-ecosystem/verified-sources/salesforce)
+To initialize the verified source, please refer to the [full documentation here.](https://dlthub.com/docs/dlt-ecosystem/verified-sources/salesforce)
 
 ## Add credentials and configs
 
@@ -51,7 +51,7 @@ To grab credentials and initialize the verified source, please refer to the [ful
     security_token = "please set me up!" # Salesforce security token generated
     ```
 
-    Alternatively, you can authenticate using one of the following methods:
+   Alternatively, you may authenticate using any method supported by the underlying `simple_salesforce` library. For instructions on obtaining these credentials, please consult Salesforce’s documentation.
 
     - IP-whitelist + organization ID:
         ```toml

--- a/sources/salesforce/README.md
+++ b/sources/salesforce/README.md
@@ -39,19 +39,74 @@ Here, we chose BigQuery as the destination. Alternatively, you can also choose r
 
 To grab credentials and initialize the verified source, please refer to the [full documentation here.](https://dlthub.com/docs/dlt-ecosystem/verified-sources/salesforce)
 
-## Add credentials
+## Add credentials and configs
 
 1. Open `.dlt/secrets.toml`.
-2. Enter the user name, password and security token:
+2. Enter the username, password and security token:
     ```toml
     # put your secret values and credentials here. do not share this file and do not push it to github
-    [sources.salesforce]
+    [sources.salesforce.credentials]
     user_name = "please set me up!" # Salesforce user name
     password = "please set me up!" # Salesforce password
     security_token = "please set me up!" # Salesforce security token generated
     ```
+
+    Alternatively, you can authenticate using one of the following methods:
+
+    - IP-whitelist + organization ID:
+        ```toml
+        [sources.salesforce.credentials]
+        user_name = "please set me up!" 
+        password = "please set me up!" 
+        organization_id = "please set me up!"
+        ```    
+
+    - Session ID + instance:
+        ```toml
+        [sources.salesforce.credentials]
+        session_id = "please set me up!" 
+        instance = "please set me up!" # OR
+        instance_url = "please set me up!"
+        ```    
+
+    - JWT method:
+        ```toml
+        [sources.salesforce.credentials]
+        user_name = "please set me up!" 
+        consumer_key = "please set me up!" 
+        privatekey_file = "please set me up!" # OR
+        privatekey = "please set me up!"
+        instance_url = "please set me up!" # Optional
+        ```    
+
+    - Connected app method:
+        ```toml
+        [sources.salesforce.credentials]
+        user_name = "please set me up!" 
+        password = "please set me up!" 
+        consumer_key = "please set me up!"
+        consumer_secret = "please set me up!"
+        ```    
     
-3. Enter credentials for your chosen destination as per the [docs.](https://dlthub.com/docs/dlt-ecosystem/destinations/)
+    - Client credentials method:
+        ```toml
+        [sources.salesforce.credentials]
+        consumer_key = "please set me up!"
+        consumer_secret = "please set me up!"
+        domain = "please set me up!"
+        ```    
+
+3. You can set up the following optional configs in your `.dlt/config.toml` file that will be used to connect to Salesforce:
+
+    ```toml
+    [sources.salesforce]
+    domain = "please set me up!" # Set to "test" if sandbox
+    version = "please set me up!" # Version of the Salesforce API to use, defaults to 59.0 
+    proxies = "please set me up!" # Mapping of protocols to proxy servers
+    client_id = "please set me up!" # App identifier for Salesforce API usage tracking
+    ```
+
+4. Enter credentials for your chosen destination as per the [docs.](https://dlthub.com/docs/dlt-ecosystem/destinations/)
 
 ## Run the pipeline example
 

--- a/sources/salesforce/__init__.py
+++ b/sources/salesforce/__init__.py
@@ -10,7 +10,7 @@ To get the security token: https://onlinehelp.coveo.com/en/ces/7.0/administrator
 from dlt.sources import DltResource
 from dlt.sources import incremental
 
-from typing import Iterable
+from typing import Iterable, overload, Dict, Union
 
 import dlt
 from simple_salesforce import Salesforce
@@ -20,11 +20,62 @@ from dlt.common.typing import TDataItem
 from .helpers import get_records
 
 
-@dlt.source(name="salesforce")
+@overload
 def salesforce_source(
     user_name: str = dlt.secrets.value,
     password: str = dlt.secrets.value,
     security_token: str = dlt.secrets.value,
+    domain: str = dlt.secrets.value,
+) -> Iterable[DltResource]:
+    """Athentication with username, password and security token"""
+    ...
+
+
+@overload
+def salesforce_source(
+    user_name: str = dlt.secrets.value,
+    password: str = dlt.secrets.value,
+    organization_id: str = dlt.secrets.value,
+    domain: str = dlt.secrets.value,
+) -> Iterable[DltResource]:
+    """Athentication with username, password and organizationId"""
+    ...
+
+
+@overload
+def salesforce_source(
+    user_name: str = dlt.secrets.value,
+    consumer_key: str = dlt.secrets.value,
+    privatekey_file: str = dlt.secrets.value,
+    domain: str = dlt.secrets.value,
+) -> Iterable[DltResource]:
+    """JWT authentication with username, consumer key and private key file"""
+    ...
+
+
+@overload
+def salesforce_source(
+    user_name: str = dlt.secrets.value,
+    password: str = dlt.secrets.value,
+    consumer_key: str = dlt.secrets.value,
+    consumer_secret: str = dlt.secrets.value,
+    domain: str = dlt.secrets.value,
+) -> Iterable[DltResource]:
+    """JWT authentication with username, consumer key and private key file"""
+    ...
+
+
+@dlt.source(name="salesforce")  # type: ignore[misc]
+def salesforce_source(
+    *,
+    user_name: str = dlt.secrets.value,
+    password: Union[str, None] = dlt.secrets.value,
+    security_token: Union[str, None] = dlt.secrets.value,
+    organization_id: Union[str, None] = dlt.secrets.value,
+    consumer_key: Union[str, None] = dlt.secrets.value,
+    consumer_secret: Union[str, None] = dlt.secrets.value,
+    privatekey_file: Union[str, None] = dlt.secrets.value,
+    domain: Union[str, None] = dlt.secrets.value,
 ) -> Iterable[DltResource]:
     """
     Retrieves data from Salesforce using the Salesforce API.
@@ -33,12 +84,26 @@ def salesforce_source(
         user_name (str): The username for authentication. Defaults to the value in the `dlt.secrets` object.
         password (str): The password for authentication. Defaults to the value in the `dlt.secrets` object.
         security_token (str): The security token for authentication. Defaults to the value in the `dlt.secrets` object.
+        organization_id (str): ID of an IP‑whitelisted organization.
+        consumer_key (str): Connected‑App consumer key.
+        consumer_secret (str): Connected‑App consumer secret.
+        privatekey_file (str): Path to the PEM‑encoded private key.
+        domain (str): Login domain (Needs to be set to "test" to enter a sandbox.)
 
     Yields:
         DltResource: Data resources from Salesforce.
     """
 
-    client = Salesforce(user_name, password, security_token)
+    client = Salesforce(
+        username=user_name,
+        password=password,
+        security_token=security_token,
+        organizationId=organization_id,
+        consumer_key=consumer_key,
+        consumer_secret=consumer_secret,
+        privatekey_file=privatekey_file,
+        domain=domain,
+    )
 
     # define resources
     @dlt.resource(write_disposition="replace")

--- a/sources/salesforce/__init__.py
+++ b/sources/salesforce/__init__.py
@@ -10,100 +10,22 @@ To get the security token: https://onlinehelp.coveo.com/en/ces/7.0/administrator
 from dlt.sources import DltResource
 from dlt.sources import incremental
 
-from typing import Iterable, overload, Dict, Union
+from typing import Iterable, Optional
 
 import dlt
-from simple_salesforce import Salesforce
+from dlt.sources.helpers.requests import Session
 from dlt.common.typing import TDataItem
 
+from .helpers.records import get_records
+from .helpers.client import SalesforceAuth, make_salesforce_client
 
-from .helpers import get_records
 
-
-@overload
+@dlt.source(name="salesforce")
 def salesforce_source(
-    user_name: str = dlt.secrets.value,
-    password: str = dlt.secrets.value,
-    security_token: str = dlt.secrets.value,
-    domain: str = dlt.secrets.value,
+    credentials: SalesforceAuth = dlt.secrets.value,
+    session: Optional[Session] = None,
 ) -> Iterable[DltResource]:
-    """Athentication with username, password and security token"""
-    ...
-
-
-@overload
-def salesforce_source(
-    user_name: str = dlt.secrets.value,
-    password: str = dlt.secrets.value,
-    organization_id: str = dlt.secrets.value,
-    domain: str = dlt.secrets.value,
-) -> Iterable[DltResource]:
-    """Athentication with username, password and organizationId"""
-    ...
-
-
-@overload
-def salesforce_source(
-    user_name: str = dlt.secrets.value,
-    consumer_key: str = dlt.secrets.value,
-    privatekey_file: str = dlt.secrets.value,
-    domain: str = dlt.secrets.value,
-) -> Iterable[DltResource]:
-    """JWT authentication with username, consumer key and private key file"""
-    ...
-
-
-@overload
-def salesforce_source(
-    user_name: str = dlt.secrets.value,
-    password: str = dlt.secrets.value,
-    consumer_key: str = dlt.secrets.value,
-    consumer_secret: str = dlt.secrets.value,
-    domain: str = dlt.secrets.value,
-) -> Iterable[DltResource]:
-    """JWT authentication with username, consumer key and private key file"""
-    ...
-
-
-@dlt.source(name="salesforce")  # type: ignore[misc]
-def salesforce_source(
-    *,
-    user_name: str = dlt.secrets.value,
-    password: Union[str, None] = dlt.secrets.value,
-    security_token: Union[str, None] = dlt.secrets.value,
-    organization_id: Union[str, None] = dlt.secrets.value,
-    consumer_key: Union[str, None] = dlt.secrets.value,
-    consumer_secret: Union[str, None] = dlt.secrets.value,
-    privatekey_file: Union[str, None] = dlt.secrets.value,
-    domain: Union[str, None] = dlt.secrets.value,
-) -> Iterable[DltResource]:
-    """
-    Retrieves data from Salesforce using the Salesforce API.
-
-    Args:
-        user_name (str): The username for authentication. Defaults to the value in the `dlt.secrets` object.
-        password (str): The password for authentication. Defaults to the value in the `dlt.secrets` object.
-        security_token (str): The security token for authentication. Defaults to the value in the `dlt.secrets` object.
-        organization_id (str): ID of an IP‑whitelisted organization.
-        consumer_key (str): Connected‑App consumer key.
-        consumer_secret (str): Connected‑App consumer secret.
-        privatekey_file (str): Path to the PEM‑encoded private key.
-        domain (str): Login domain (Needs to be set to "test" to enter a sandbox.)
-
-    Yields:
-        DltResource: Data resources from Salesforce.
-    """
-
-    client = Salesforce(
-        username=user_name,
-        password=password,
-        security_token=security_token,
-        organizationId=organization_id,
-        consumer_key=consumer_key,
-        consumer_secret=consumer_secret,
-        privatekey_file=privatekey_file,
-        domain=domain,
-    )
+    client = make_salesforce_client(credentials, session)
 
     # define resources
     @dlt.resource(write_disposition="replace")

--- a/sources/salesforce/helpers.py
+++ b/sources/salesforce/helpers.py
@@ -2,13 +2,49 @@
 
 import pendulum
 
-from typing import Optional, Iterable
+from typing import Optional, Iterable, Dict, Set, Any, cast
 
+from simple_salesforce.exceptions import SalesforceMalformedRequest
 from simple_salesforce import Salesforce
 from dlt.common.typing import TDataItem
 
 
 from .settings import IS_PRODUCTION
+
+
+def _process_record(
+    record: Dict[str, Any], date_fields: Set[str], is_bulk_api: bool = False
+) -> Dict[str, Any]:
+    """
+    Process a single Salesforce record by removing attributes and converting date fields.
+
+    Args:
+        record: The record to process
+        date_fields: Set of field names that contain date/datetime values
+        is_bulk_api: Whether this record came from Bulk API (timestamps) or standard API (ISO strings)
+
+    Returns:
+        The processed record
+    """
+    # Strip out the attributes field
+    record.pop("attributes", None)
+
+    for field in date_fields:
+        if record.get(field):
+            if is_bulk_api:
+                # Bulk API returns timestamps, convert to ISO 8601
+                record[field] = pendulum.from_timestamp(
+                    record[field] / 1000,
+                ).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+            else:
+                # Standard API returns ISO strings, ensure consistent format
+                if record[field]:
+                    # pendulum.parse can also return Date, Time or Duration
+                    # Salesforce date/datetime fields are always DateTime
+                    dt = cast(pendulum.DateTime, pendulum.parse(record[field]))
+                    record[field] = dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+    return record
 
 
 def get_records(
@@ -38,7 +74,9 @@ def get_records(
         for f in desc["fields"]
         if f["compoundFieldName"] is not None
     } - {"Name"}
-    # Salesforce returns datetime fields as timestamps, so we need to convert them
+
+    # Fields of type "datetime" (Bulk API returns them as timestamps,
+    # Standard API returns ISO strings). We normalize them later.
     date_fields = {
         f["name"] for f in desc["fields"] if f["type"] in ("datetime",) and f["name"]
     }
@@ -55,16 +93,31 @@ def get_records(
     if not IS_PRODUCTION:
         query += " LIMIT 100"
 
-    # Query all records in batches
-    for page in getattr(sf.bulk, sobject).query_all(query, lazy_operation=True):
-        for record in page:
-            # Strip out the attributes field
-            record.pop("attributes", None)
-            for field in date_fields:
-                # Convert Salesforce timestamps to ISO 8601
-                if record.get(field):
-                    record[field] = pendulum.from_timestamp(
-                        record[field] / 1000,
-                    ).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-        yield from page
-        n_records += len(page)
+    # Try Bulk API first, fallback to standard SOQL if not available
+    try:
+        # Query all records in batches using Bulk API
+        for page in getattr(sf.bulk, sobject).query_all(query, lazy_operation=True):
+            processed_page = [
+                _process_record(record, date_fields, is_bulk_api=True)
+                for record in page
+            ]
+            yield from processed_page
+            n_records += len(processed_page)
+    except SalesforceMalformedRequest as e:
+        if "FeatureNotEnabled" in str(e) and "Async API not enabled" in str(e):
+            # Fallback to standard SOQL API
+            result = sf.query(query)
+            while True:
+                for record in result["records"]:
+                    processed_record = _process_record(
+                        record, date_fields, is_bulk_api=False
+                    )
+                    yield processed_record
+                    n_records += 1
+
+                # Check if there are more records to fetch
+                if result["done"]:
+                    break
+                result = sf.query_more(result["nextRecordsUrl"])
+        else:
+            raise

--- a/sources/salesforce/helpers/client.py
+++ b/sources/salesforce/helpers/client.py
@@ -23,7 +23,9 @@ class SalesforceClientConfiguration(BaseConfiguration):
     proxies: Optional[str] = None
     client_id: Optional[str] = None
 
-    def get_proxies(self) -> Proxies:
+    def get_proxies(self) -> Optional[Proxies]:
+        if self.proxies is None:
+            return None
         return cast(Proxies, json.loads(self.proxies))
 
 
@@ -137,13 +139,12 @@ def make_salesforce_client(
     Note that version, domain, session and proxies are universal kwargs used for all authentication types in
     the Salesforce object.
     """
-    proxies = config.get_proxies() if config.proxies else None
     if isinstance(credentials, SecurityTokenAuth):
         return Salesforce(
             version=config.version,
             domain=config.domain,
             session=session,
-            proxies=proxies,
+            proxies=config.get_proxies(),
             username=credentials.user_name,
             password=credentials.password,
             security_token=credentials.security_token,
@@ -155,7 +156,7 @@ def make_salesforce_client(
             version=config.version,
             domain=config.domain,
             session=session,
-            proxies=proxies,
+            proxies=config.get_proxies(),
             session_id=credentials.session_id,
             instance=credentials.instance,
             instance_url=credentials.instance_url,
@@ -166,7 +167,7 @@ def make_salesforce_client(
             version=config.version,
             domain=config.domain,
             session=session,
-            proxies=proxies,
+            proxies=config.get_proxies(),
             username=credentials.user_name,
             password=credentials.password,
             organizationId=credentials.organization_id,
@@ -178,7 +179,7 @@ def make_salesforce_client(
             version=config.version,
             domain=config.domain,
             session=session,
-            proxies=proxies,
+            proxies=config.get_proxies(),
             username=credentials.user_name,
             password=credentials.password,
             consumer_key=credentials.consumer_key,
@@ -190,7 +191,7 @@ def make_salesforce_client(
             version=config.version,
             domain=config.domain,
             session=session,
-            proxies=proxies,
+            proxies=config.get_proxies(),
             username=credentials.user_name,
             instance_url=credentials.instance_url,
             consumer_key=credentials.consumer_key,
@@ -203,7 +204,7 @@ def make_salesforce_client(
         return Salesforce(
             version=config.version,
             session=session,
-            proxies=proxies,
+            proxies=config.get_proxies(),
             consumer_key=credentials.consumer_key,
             consumer_secret=credentials.consumer_secret,
             domain=credentials.domain,

--- a/sources/salesforce/helpers/client.py
+++ b/sources/salesforce/helpers/client.py
@@ -1,0 +1,213 @@
+from typing import Optional, Union, cast
+
+import json
+
+from dlt.sources.helpers.requests import Session
+from simple_salesforce import Salesforce
+from simple_salesforce.util import Proxies
+from simple_salesforce.api import DEFAULT_API_VERSION
+from dlt.common.typing import TSecretStrValue
+from dlt.common.configuration.specs import (
+    CredentialsConfiguration,
+    configspec,
+    BaseConfiguration,
+)
+from dlt.common.configuration import with_config
+from dlt.common.configuration.exceptions import ConfigurationValueError
+
+
+@configspec
+class SalesforceClientConfiguration(BaseConfiguration):
+    domain: Optional[str] = None
+    version: Optional[str] = DEFAULT_API_VERSION
+    proxies: Optional[str] = None
+    client_id: Optional[str] = None
+
+    def get_proxies(self) -> Proxies:
+        return cast(Proxies, json.loads(self.proxies))
+
+
+@configspec
+class SalesforceCredentialsBase(CredentialsConfiguration):
+    """
+    The base version of all the SalesforceCredential classes.
+    """
+
+
+@configspec
+class SecurityTokenAuth(SalesforceCredentialsBase):
+    """
+    This class is used to store 'OAuth 2.0 Username Password Flow Credentials' based on a security token.
+    """
+
+    user_name: str = None
+    password: TSecretStrValue = None
+    security_token: TSecretStrValue = None
+
+
+@configspec
+class OrganizationIdAuth(SalesforceCredentialsBase):
+    """
+    This class is used to store credentials based on `Trusted IP Ranges` in Salesforce.
+    """
+
+    user_name: str = None
+    password: TSecretStrValue = None
+    organization_id: TSecretStrValue = None
+
+
+@configspec
+class InstanceAuth(SalesforceCredentialsBase):
+    """
+    This class is used to store credentials for direct session access.
+    """
+
+    session_id: str = None
+    instance: Optional[TSecretStrValue] = None
+    instance_url: Optional[TSecretStrValue] = None
+
+    def on_resolved(self) -> None:
+        if not self.instance and not self.instance_url:
+            raise ConfigurationValueError(
+                "InstanceAuth requires either 'instance' or 'instance_url' to be configured. "
+                "Please provide one of these fields."
+            )
+
+
+@configspec
+class ConsumerKeySecretAuth(SalesforceCredentialsBase):
+    """
+    This class is used to store 'OAuth 2.0 Username Password Flow Credentials' based on a connected app.
+    """
+
+    user_name: str = None
+    password: TSecretStrValue = None
+    consumer_key: TSecretStrValue = None
+    consumer_secret: TSecretStrValue = None
+
+
+@configspec
+class JWTAuth(SalesforceCredentialsBase):
+    """
+    This class is used to store 'OAuth 2.0 JWT Bearer Flow Credentials'.
+    """
+
+    user_name: str = None
+    consumer_key: TSecretStrValue = None
+    privatekey_file: Optional[TSecretStrValue] = None
+    privatekey: Optional[TSecretStrValue] = None
+    instance_url: Optional[TSecretStrValue] = None
+
+    def on_resolved(self) -> None:
+        if not self.privatekey_file and not self.privatekey:
+            raise ConfigurationValueError(
+                "JWTAuth requires either 'privatekey_file' or 'privatekey' to be configured. "
+                "Please provide one of these fields."
+            )
+
+
+@configspec
+class ConsumerKeySecretDomainAuth(SalesforceCredentialsBase):
+    """
+    This class is used to store 'OAuth 2.0 Client Credentials Flow'.
+    """
+
+    consumer_key: TSecretStrValue = None
+    consumer_secret: TSecretStrValue = None
+    domain: str = None
+
+
+SalesforceAuth = Union[
+    SecurityTokenAuth,
+    OrganizationIdAuth,
+    ConsumerKeySecretAuth,
+    JWTAuth,
+    ConsumerKeySecretDomainAuth,
+    InstanceAuth,
+]
+
+
+@with_config(spec=SalesforceClientConfiguration)
+def make_salesforce_client(
+    credentials: SalesforceAuth,
+    session: Optional[Session] = None,
+    config: SalesforceClientConfiguration = None,
+) -> Salesforce:
+    """This function passes only the necessary arguments to Salesforce depending on the authentication type.
+    Note that version, domain, session and proxies are universal kwargs used for all authentication types in
+    the Salesforce object.
+    """
+    proxies = config.get_proxies() if config.proxies else None
+    if isinstance(credentials, SecurityTokenAuth):
+        return Salesforce(
+            version=config.version,
+            domain=config.domain,
+            session=session,
+            proxies=proxies,
+            username=credentials.user_name,
+            password=credentials.password,
+            security_token=credentials.security_token,
+            client_id=config.client_id,
+        )
+
+    elif isinstance(credentials, InstanceAuth):
+        return Salesforce(
+            version=config.version,
+            domain=config.domain,
+            session=session,
+            proxies=proxies,
+            session_id=credentials.session_id,
+            instance=credentials.instance,
+            instance_url=credentials.instance_url,
+        )
+
+    elif isinstance(credentials, OrganizationIdAuth):
+        return Salesforce(
+            version=config.version,
+            domain=config.domain,
+            session=session,
+            proxies=proxies,
+            username=credentials.user_name,
+            password=credentials.password,
+            organizationId=credentials.organization_id,
+            client_id=config.client_id,
+        )
+
+    elif isinstance(credentials, ConsumerKeySecretAuth):
+        return Salesforce(
+            version=config.version,
+            domain=config.domain,
+            session=session,
+            proxies=proxies,
+            username=credentials.user_name,
+            password=credentials.password,
+            consumer_key=credentials.consumer_key,
+            consumer_secret=credentials.consumer_secret,
+        )
+
+    elif isinstance(credentials, JWTAuth):
+        return Salesforce(
+            version=config.version,
+            domain=config.domain,
+            session=session,
+            proxies=proxies,
+            username=credentials.user_name,
+            instance_url=credentials.instance_url,
+            consumer_key=credentials.consumer_key,
+            privatekey_file=credentials.privatekey_file,
+            privatekey=credentials.privatekey,
+        )
+    elif isinstance(credentials, ConsumerKeySecretDomainAuth):
+        # NOTE: For this authentication type, domain must be provided as part of the credentials set,
+        # we therefore get it from credentials, not config
+        return Salesforce(
+            version=config.version,
+            session=session,
+            proxies=proxies,
+            consumer_key=credentials.consumer_key,
+            consumer_secret=credentials.consumer_secret,
+            domain=credentials.domain,
+        )
+
+    else:
+        raise TypeError("You should provide a valid set of credentials.")

--- a/sources/salesforce/helpers/records.py
+++ b/sources/salesforce/helpers/records.py
@@ -37,7 +37,7 @@ def _process_record(
                     record[field] / 1000,
                 ).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
             else:
-                # Standard API return ISO strings, ensure consistent format
+                # Standard API returns ISO strings, ensure consistent format
                 if record[field]:
                     # pendulum.parse can also return Date, Time or Duration
                     # Salesforce date/datetime fields are always DateTime

--- a/tests/salesforce/test_salesforce_source.py
+++ b/tests/salesforce/test_salesforce_source.py
@@ -1,7 +1,13 @@
+from typing import OrderedDict
+import inspect
 from tests.utils import ALL_DESTINATIONS, assert_load_info, load_table_counts
 import pytest
+from dlt.common import pendulum
 import dlt
 from sources.salesforce import salesforce_source
+from sources.salesforce.helpers.records import _process_record
+from simple_salesforce import Salesforce
+from dlt.sources.helpers.requests import Session
 
 
 @pytest.mark.parametrize("destination_name", ALL_DESTINATIONS)
@@ -25,6 +31,7 @@ def test_all_resources(destination_name: str) -> None:
         dataset_name="salesforce_data",
         dev_mode=True,
     )
+
     source = salesforce_source()
 
     # Execute the pipeline
@@ -35,10 +42,10 @@ def test_all_resources(destination_name: str) -> None:
     table_counts = load_table_counts(pipeline, *table_names)
 
     assert set(table_counts.keys()) >= set(expected_tables)
-    assert table_counts["sf_user"] == 7
-    assert table_counts["account"] == 13
+    assert table_counts["sf_user"] == 8
+    assert table_counts["account"] == 19
     assert table_counts["campaign"] == 4
-    assert table_counts["contact"] == 20
+    assert table_counts["contact"] == 26
     assert table_counts["lead"] == 22
     assert table_counts["opportunity"] == 31
     assert table_counts["pricebook_2"] == 2
@@ -55,3 +62,56 @@ def test_all_resources(destination_name: str) -> None:
     table_names = [t["name"] for t in pipeline.default_schema.data_tables()]
     new_table_counts = load_table_counts(pipeline, *table_names)
     assert new_table_counts == table_counts
+
+
+@pytest.mark.parametrize(
+    "api_type",
+    ["bulk", "standard"],
+)
+def test_process_record(api_type: str) -> None:
+    date_fields = {"LastModifiedDate", "SystemModstamp", "CreatedDate"}
+    sample_data = OrderedDict(
+        [
+            (
+                "attributes",
+                OrderedDict(
+                    [
+                        ("type", "Contact"),
+                        (
+                            "url",
+                            "/services/data/v59.0/sobjects/Contact/003Wz00000E9PTuIAN",
+                        ),
+                    ]
+                ),
+            ),
+            ("Id", "003Wz00000E9PTuIAN"),
+            (
+                "CreatedDate",
+                "2025-08-06T14:16:08.000+0000"
+                if api_type == "standard"
+                else 1754489768000,
+            ),
+            (
+                "LastModifiedDate",
+                "2025-08-06T14:16:08.000+0000"
+                if api_type == "standard"
+                else 1754489768000,
+            ),
+            (
+                "SystemModstamp",
+                "2025-08-06T14:16:08.000+0000"
+                if api_type == "standard"
+                else 1754489768000,
+            ),
+        ]
+    )
+
+    processed_record = _process_record(sample_data, date_fields, api_type=api_type)
+    assert "attributes" not in processed_record
+    for date_field in date_fields:
+        try:
+            pendulum.DateTime.strptime(
+                processed_record[date_field], "%Y-%m-%dT%H:%M:%S.%fZ"
+            )
+        except ValueError:
+            raise AssertionError("Value does not match format %Y-%m-%dT%H:%M:%S.%fZ")

--- a/tests/salesforce/test_salesforce_source.py
+++ b/tests/salesforce/test_salesforce_source.py
@@ -1,13 +1,10 @@
-from typing import OrderedDict
-import inspect
+from collections import OrderedDict
 from tests.utils import ALL_DESTINATIONS, assert_load_info, load_table_counts
 import pytest
 from dlt.common import pendulum
 import dlt
 from sources.salesforce import salesforce_source
 from sources.salesforce.helpers.records import _process_record
-from simple_salesforce import Salesforce
-from dlt.sources.helpers.requests import Session
 
 
 @pytest.mark.parametrize("destination_name", ALL_DESTINATIONS)
@@ -87,19 +84,19 @@ def test_process_record(api_type: str) -> None:
             ("Id", "003Wz00000E9PTuIAN"),
             (
                 "CreatedDate",
-                "2025-08-06T14:16:08.000+0000"
+                "2020-08-06T14:16:08.000+0000"
                 if api_type == "standard"
                 else 1754489768000,
             ),
             (
                 "LastModifiedDate",
-                "2025-08-06T14:16:08.000+0000"
+                "2020-08-06T14:16:08.000+0000"
                 if api_type == "standard"
                 else 1754489768000,
             ),
             (
                 "SystemModstamp",
-                "2025-08-06T14:16:08.000+0000"
+                "2020-08-06T14:16:08.000+0000"
                 if api_type == "standard"
                 else 1754489768000,
             ),


### PR DESCRIPTION
This PR enables different auth methods for the salesforce source that are supported by the underlying simple_salesforce package.

Additionally, the standard api is enabled if bulk api is not available in Salesforce - this applies to Salesforce trial accounts that users may test this source with.  

Relates to #639 