### PR TITLE
Fix: Invoice moved to non incremental endpoints

### DIFF
--- a/sources/stripe_analytics/settings.py
+++ b/sources/stripe_analytics/settings.py
@@ -7,8 +7,9 @@ ENDPOINTS = (
     "Account",
     "Coupon",
     "Customer",
+    "Invoice",
     "Product",
     "Price",
 )
 # possible incremental endpoints
-INCREMENTAL_ENDPOINTS = ("Event", "Invoice", "BalanceTransaction")
+INCREMENTAL_ENDPOINTS = ("Event", "BalanceTransaction")


### PR DESCRIPTION
This PR moves `Invoice` to `ENDPOINTS` from `INCREMENTAL_ENDPOINTS`

**Reason:** The invoice endpoint pulls draft invoices as well. Since draft invoices are editable, the `Invoice` endpoint should be in the ENDPOINTS, not `INCREMENTAL_ENDPOINTS`. 

Resolves #632 