### PR TITLE
Fix: fix missing data types (#652)

### DIFF
--- a/sources/pg_replication/schema_types.py
+++ b/sources/pg_replication/schema_types.py
@@ -38,8 +38,10 @@ _PG_TYPES: Dict[int, str] = {
     1043: "character varying",
     1082: "date",
     1083: "time without time zone",
+    1114: "timestamp without time zone",
     1184: "timestamp with time zone",
     1700: "numeric",
+    114: "json",
     3802: "jsonb",
 }
 """Maps postgres type OID to type string. Only includes types present in PostgresTypeMapper."""


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
<!--
Pick the relevant item or items and remove the rest: 
-->
- fixing a bug [#652](https://github.com/dlt-hub/verified-sources/issues/652)

### Short description
`pg_replication` source doesn't handle correctly `json` (OID 114) and `timestamp` (OID 1114) data types.  It treats these types as text, which cause wrong data in destination and even crashing.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #652 

### Additional Context

<!--
Please ensure that
    - you have read the [Contributing Guide](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
