### PR TITLE
Fix: google sheets ranges with hyphens are not recognized

### DIFF
--- a/sources/google_sheets/helpers/data_processing.py
+++ b/sources/google_sheets/helpers/data_processing.py
@@ -19,7 +19,7 @@ DLT_TIMEZONE = "UTC"
 TIMESTAMP_CONST = -2209161600.0
 # compiled regex to extract ranges
 RE_PARSE_RANGE = re.compile(
-    r"^(?:(?P<sheet>[\'\w\s]+)!)?(?P<start_col>[A-Z]+)(?P<start_row>\d+):(?P<end_col>[A-Z]+)(?P<end_row>\d+)$"
+    r"^(?:(?P<sheet>[\'\w\s\-]+)!)?(?P<start_col>[A-Z]+)(?P<start_row>\d+):(?P<end_col>[A-Z]+)(?P<end_row>\d+)$"
 )
 
 

--- a/tests/google_sheets/test_google_sheets_source.py
+++ b/tests/google_sheets/test_google_sheets_source.py
@@ -2,7 +2,7 @@ from typing import Tuple
 
 import pytest
 import dlt
-from datetime import date # noqa: I251
+from datetime import date  # noqa: I251
 from dlt.common.pipeline import LoadInfo
 from sources.google_sheets import google_spreadsheet
 from tests.utils import (
@@ -37,7 +37,7 @@ ALL_RANGES = {
     "trailing_empty_cols_1",
     "trailing_empty_cols_2",
     "trailing_empty_cols_3",
-    "trailing_empty_col_date",
+    "trailing_empty_col-date",
 }
 
 SKIPPED_RANGES = {
@@ -774,11 +774,11 @@ def test_trailing_empty_col_date(with_hints: bool) -> None:
     )
     data = google_spreadsheet(
         "1HhWHjqouQnnCIZAFa2rL6vT91YRN8aIhts22SUUR580",
-        range_names=["trailing_empty_cols_1", "trailing_empty_col_date"],
+        range_names=["trailing_empty_cols_1", "trailing_empty_col-date"],
         get_named_ranges=False,
     )
     if with_hints:
-        data.trailing_empty_col_date.apply_hints(
+        data.resources["trailing_empty_col-date"].apply_hints(
             columns={"Start Date": {"data_type": "date"}}
         )
     info = pipeline.run(data)


### PR DESCRIPTION
This PR simply updates the `RE_PARSE_RANGE` in `sources.google_sheets.helpers.data_processing.py` so that sheet names with hyphens are recognized. On of the existing tests, specifically the `test_trailing_empty_col_date` test is adjusted to use a sheet name with a hyphen.

Resolves #651 

