### PR TITLE
Fix: Timestamp without timezone, regular json data types in pg_replication

### DIFF
--- a/sources/pg_replication/schema_types.py
+++ b/sources/pg_replication/schema_types.py
@@ -42,6 +42,7 @@ _PG_TYPES: Dict[int, str] = {
     1184: "timestamp with time zone",
     1700: "numeric",
     3802: "jsonb",
+    114: "json",
 }
 """Maps postgres type OID to type string. Only includes types present in PostgresTypeMapper."""
 
@@ -99,7 +100,14 @@ def _to_dlt_column_type(type_id: int, atttypmod: int) -> TColumnType:
         pg_type = "character varying"
     precision = _get_precision(type_id, atttypmod)
     scale = _get_scale(type_id, atttypmod)
-    return _type_mapper().from_destination_type(pg_type, precision, scale)
+    dlt_type = _type_mapper().from_destination_type(pg_type, precision, scale)
+
+    # Set timezone flag for timestamp types
+    if type_id == 1114:  # timestamp without time zone
+        dlt_type["timezone"] = False
+    elif type_id == 1184:  # timestamp with time zone
+        dlt_type["timezone"] = True
+    return dlt_type
 
 
 def _to_dlt_column_schema(col: ColumnType) -> TColumnSchema:

--- a/sources/pg_replication/schema_types.py
+++ b/sources/pg_replication/schema_types.py
@@ -38,6 +38,7 @@ _PG_TYPES: Dict[int, str] = {
     1043: "character varying",
     1082: "date",
     1083: "time without time zone",
+    1114: "timestamp without time zone",
     1184: "timestamp with time zone",
     1700: "numeric",
     3802: "jsonb",

--- a/tests/pg_replication/cases.py
+++ b/tests/pg_replication/cases.py
@@ -5,6 +5,7 @@ from dlt.common.schema import TColumnSchema, TTableSchemaColumns
 
 
 TABLE_ROW_ALL_DATA_TYPES = {
+    "col0": "2022-05-23 13:26:45.176451",
     "col1": 989127831,
     "col2": 898912.821982,
     "col3": True,
@@ -41,10 +42,11 @@ TABLE_ROW_ALL_DATA_TYPES = {
     "col11_precision": "13:26:45.176451",
 }
 TABLE_UPDATE: List[TColumnSchema] = [
+    {"name": "col0", "data_type": "timestamp", "nullable": False, "timezone": False},
     {"name": "col1", "data_type": "bigint", "nullable": False},
     {"name": "col2", "data_type": "double", "nullable": False},
     {"name": "col3", "data_type": "bool", "nullable": False},
-    {"name": "col4", "data_type": "timestamp", "nullable": False},
+    {"name": "col4", "data_type": "timestamp", "nullable": False, "timezone": True},
     {"name": "col5", "data_type": "text", "nullable": False},
     {"name": "col6", "data_type": "decimal", "nullable": False},
     {"name": "col7", "data_type": "binary", "nullable": False},

--- a/tests/pg_replication/cases.py
+++ b/tests/pg_replication/cases.py
@@ -5,7 +5,6 @@ from dlt.common.schema import TColumnSchema, TTableSchemaColumns
 
 
 TABLE_ROW_ALL_DATA_TYPES = {
-    "col0": "2022-05-23 13:26:45.176451",
     "col1": 989127831,
     "col2": 898912.821982,
     "col3": True,
@@ -42,11 +41,10 @@ TABLE_ROW_ALL_DATA_TYPES = {
     "col11_precision": "13:26:45.176451",
 }
 TABLE_UPDATE: List[TColumnSchema] = [
-    {"name": "col0", "data_type": "timestamp", "nullable": False, "timezone": False},
     {"name": "col1", "data_type": "bigint", "nullable": False},
     {"name": "col2", "data_type": "double", "nullable": False},
     {"name": "col3", "data_type": "bool", "nullable": False},
-    {"name": "col4", "data_type": "timestamp", "nullable": False, "timezone": True},
+    {"name": "col4", "data_type": "timestamp", "nullable": False},
     {"name": "col5", "data_type": "text", "nullable": False},
     {"name": "col6", "data_type": "decimal", "nullable": False},
     {"name": "col7", "data_type": "binary", "nullable": False},


### PR DESCRIPTION
This PR is a continuation of #652 that addresses the following problem: `pg_replication` source doesn't handle json (OID 114) and timestamp (OID 1114) data types correctly.

The types were added to the type mapper, along with appropriate tests.

Resolves #652 
