### PR TITLE
Fix Pipedrive set custom field string mapping

### DIFF
--- a/sources/pipedrive/helpers/custom_fields_munger.py
+++ b/sources/pipedrive/helpers/custom_fields_munger.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, TypedDict, Optional
+from typing import Any, Dict, TypedDict, Optional, List
 
 import dlt
 
@@ -93,6 +93,7 @@ def rename_fields(data: TDataPage, fields_mapping: Dict[str, Any]) -> TDataPage:
             options_map = field["options"]
             # Get label instead of ID for 'enum' and 'set' fields
             if field_value and field["field_type"] == "set":  # Multiple choice
+                field_value = _coerce_set_field_value(field_value)
                 field_value = [
                     options_map.get(str(enum_id), enum_id) for enum_id in field_value
                 ]
@@ -100,3 +101,18 @@ def rename_fields(data: TDataPage, fields_mapping: Dict[str, Any]) -> TDataPage:
                 field_value = options_map.get(str(field_value), field_value)
             data_item[field_name] = field_value
     return data
+
+
+def _coerce_set_field_value(field_value: Any) -> List[Any]:
+    """Normalize Pipedrive `set` custom fields to a list of option ids."""
+    if isinstance(field_value, str):
+        return [
+            option_id.strip()
+            for option_id in field_value.split(",")
+            if option_id.strip()
+        ]
+    if isinstance(field_value, list):
+        return field_value
+    if isinstance(field_value, tuple):
+        return list(field_value)
+    return [field_value]

--- a/tests/pipedrive/test_pipedrive_source.py
+++ b/tests/pipedrive/test_pipedrive_source.py
@@ -439,6 +439,28 @@ def test_rename_fields_with_set() -> None:
     assert result == [{"custom_field_1": ["b", "a", "c"], "id": 44, "name": "asdf"}]
 
 
+def test_rename_fields_with_set_csv_string() -> None:
+    data_item = {"random_hash_1": "62,63,65", "id": 44, "name": "asdf"}
+    mapping = {
+        "random_hash_1": {
+            "name": "services",
+            "normalized_name": "services",
+            "field_type": "set",
+            "options": {"62": "Service A", "63": "Service B", "65": "Service C"},
+        }
+    }
+
+    result = rename_fields([data_item], mapping)
+
+    assert result == [
+        {
+            "services": ["Service A", "Service B", "Service C"],
+            "id": 44,
+            "name": "asdf",
+        }
+    ]
+
+
 def test_recents_none_data_items_from_recents() -> None:
     pytest.skip("Unskip after setting up credentials.")
     """Pages from /recents sometimes contain `None` data items which cause errors.


### PR DESCRIPTION
### Tell us what you do here

- fixing a bug
- improving an existing source

### Short description

Fixes Pipedrive V1 custom field mapping for `set` fields returned as comma-separated strings.

Previously, values like `"62,63,65"` were treated as generic iterables, so the mapper iterated over each character and produced values like `"6"`, `"2"`, `","`, etc. This change normalizes string `set` values into option IDs before mapping them to readable option labels.

Added a regression test covering comma-separated Pipedrive `set` custom field values.

### Related Issues

No related issue. This was found while debugging Pipedrive custom field loading locally.