### PR TITLE
fix: ignore pgoutput Type messages

### DIFF
--- a/sources/pg_replication/helpers.py
+++ b/sources/pg_replication/helpers.py
@@ -705,6 +705,8 @@ class MessageConsumer:
                 "The truncate operation is currently not supported. "
                 "Truncate replication messages are ignored."
             )
+        elif op == 89:  # ASCII for 'Y'
+            pass  # Type messages describe custom types and do not carry row changes.
         else:
             raise ValueError(f"Unknown replication op {op}")
 

--- a/tests/pg_replication/test_pg_replication.py
+++ b/tests/pg_replication/test_pg_replication.py
@@ -1,5 +1,6 @@
 import pytest
 
+from types import SimpleNamespace
 from typing import Set, Tuple
 from copy import deepcopy
 from psycopg2.errors import InsufficientPrivilege
@@ -15,6 +16,7 @@ from tests.utils import (
 )
 from sources.pg_replication import replication_resource
 from sources.pg_replication.helpers import (
+    MessageConsumer,
     init_replication,
     get_pg_version,
 )
@@ -22,6 +24,15 @@ from sources.pg_replication.exceptions import IncompatiblePostgresVersionExcepti
 
 from .cases import TABLE_ROW_ALL_DATA_TYPES, TABLE_UPDATE_COLUMNS_SCHEMA
 from .utils import add_pk, assert_loaded_data, is_super_user
+
+
+def test_message_consumer_ignores_type_message() -> None:
+    consumer = MessageConsumer(upto_lsn=0, pub_ops={})
+
+    consumer.process_msg(SimpleNamespace(payload=b"Y"))  # type: ignore[arg-type]
+
+    assert consumer.data_items == {}
+    assert consumer.consumed_all is False
 
 
 @pytest.mark.parametrize("destination_name", ALL_DESTINATIONS)


### PR DESCRIPTION
## Description

Postgres pgoutput can emit `Y` Type messages when custom types are present in the publication stream. `MessageConsumer` currently treats any unrecognized op as fatal, so a Type message raises `ValueError: Unknown replication op 89` even though it does not contain row changes.

This PR makes `MessageConsumer` ignore op `89` / `Y` and adds a small regression test for that no-op behavior.

Addresses dlt-hub/dlt#4102.

## Validation

- `uv run pytest tests/pg_replication/test_pg_replication.py::test_message_consumer_ignores_type_message -q`
- `uv run black --check sources/pg_replication/helpers.py tests/pg_replication/test_pg_replication.py`
- `uv run flake8 --extend-ignore=W503 sources/pg_replication/helpers.py tests/pg_replication/test_pg_replication.py`

Note: plain `uv run flake8 sources/pg_replication/helpers.py tests/pg_replication/test_pg_replication.py` still reports pre-existing W503 line-break warnings in unchanged lines; no new lint issues are introduced by this patch.