### PR TITLE
fix(shopify): remove stray debug print from partner GraphQL pagination

### DIFF
--- a/sources/shopify_dlt/helpers.py
+++ b/sources/shopify_dlt/helpers.py
@@ -135,7 +135,6 @@ class ShopifyPartnerApi:
         variables = dict(variables or {})
         while True:
             data = self.run_graphql_query(query, variables)
-            print(data)
             data_items = jsonpath.find_values(data_items_path, data)
             if not data_items:
                 break


### PR DESCRIPTION
`ShopifyPartnerApi.get_graphql_pages` prints every raw API response page to stdout. For any real partner query that means pages of raw JSON echoed to the console, or to an orchestrator's logs, on every scheduled run — and partner transaction data isn't something to write into logs by default.

One line removed, no behaviour change otherwise. Spotted while building a Shopify pipeline with dlt and reading the verified source for reference.
